### PR TITLE
chore: change sqlite db filename

### DIFF
--- a/.env_local
+++ b/.env_local
@@ -5,7 +5,7 @@ NODE_TYPE=delta-main
 
 # Database configuration
 MODE=standalone # HA
-DB_DSN=stg-deal-maker
+DB_DSN=delta.db
 #REPO=/mnt/.whypfs # shared mounted repo
 
 # Frequencies

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NODE_TYPE=delta-main
 
 # Database configuration
 MODE=standalone
-DB_DSN=stg-deal-maker
+DB_DSN=delta.db
 #REPO=/mnt/.whypfs # shared mounted repo
 
 # Frequencies

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ type DeltaConfig struct {
 
 	Common struct {
 		Mode            string `env:"MODE" envDefault:"standalone"`
-		DBDSN           string `env:"DB_DSN" envDefault:"stg-deal-maker"`
+		DBDSN           string `env:"DB_DSN" envDefault:"delta.db"`
 		EnableWebsocket bool   `env:"ENABLE_WEBSOCKET" envDefault:"false"`
 		CommpMode       string `env:"COMMP_MODE" envDefault:"filboost"` // option "parallel"
 		StatsCollection bool   `env:"STATS_COLLECTION" envDefault:"true"`


### PR DESCRIPTION
I did this for consistency, in ddm the database is called `delta-dm.db`, so it makes sense for this one to be `delta.db` 