### PR TITLE
use lib

### DIFF
--- a/core/commp.go
+++ b/core/commp.go
@@ -5,38 +5,17 @@ import (
 	"context"
 	"fmt"
 	"github.com/application-research/filclient"
-	"github.com/filecoin-project/go-commp-utils/nonffi"
 	"github.com/filecoin-project/go-commp-utils/writer"
-	"github.com/filecoin-project/go-commp-utils/zerocomm"
-	commcid "github.com/filecoin-project/go-fil-commcid"
-	commp "github.com/filecoin-project/go-fil-commp-hashhash"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/labstack/gommon/log"
-	"golang.org/x/xerrors"
 	"io"
-	"math/bits"
-	"runtime"
 )
 
 type CommpService struct {
 	DeltaNode *DeltaNode
-}
-
-type DataCIDSize struct {
-	PayloadSize int64
-	PieceSize   abi.PaddedPieceSize
-	PieceCID    cid.Cid
-}
-
-const commPBufPad = abi.PaddedPieceSize(8 << 20)
-const CommPBuf = abi.UnpaddedPieceSize(commPBufPad - (commPBufPad / 128)) // can't use .Unpadded() for const
-
-type ciderr struct {
-	c   cid.Cid
-	err error
 }
 
 // GenerateCommPFile Generating a CommP file from a payload file.
@@ -95,13 +74,13 @@ func (c CommpService) GenerateCommPCarV2(readerFromFile io.Reader) (*abi.PieceIn
 }
 
 // Generating a CommP file from a CARv2 file.
-func (c CommpService) GenerateParallelCommp(readerFromFile io.Reader) (DataCIDSize, error) {
+func (c CommpService) GenerateParallelCommp(readerFromFile io.Reader) (writer.DataCIDSize, error) {
 	bytesFromCar, err := io.ReadAll(readerFromFile)
 	if err != nil {
-		return DataCIDSize{}, err
+		return writer.DataCIDSize{}, err
 	}
 
-	writer := &DataCidWriter{}
+	writer := &writer.Writer{}
 	writer.Write(bytesFromCar)
 	return writer.Sum()
 }
@@ -129,133 +108,4 @@ func (c CommpService) GetCarSize(stream io.Reader, rd *carv2.Reader) (int64, err
 		size = int64(len(bytes))
 	}
 	return size, nil
-}
-
-type DataCidWriter struct {
-	len    int64
-	buf    [CommPBuf]byte
-	leaves []chan ciderr
-
-	tbufs    [][CommPBuf]byte
-	throttle chan int
-}
-
-func (w *DataCidWriter) Write(p []byte) (int, error) {
-	if w.throttle == nil {
-		w.throttle = make(chan int, runtime.NumCPU())
-		for i := 0; i < cap(w.throttle); i++ {
-			w.throttle <- i
-		}
-	}
-	if w.tbufs == nil {
-		w.tbufs = make([][CommPBuf]byte, cap(w.throttle))
-	}
-
-	n := len(p)
-	for len(p) > 0 {
-		buffered := int(w.len % int64(len(w.buf)))
-		toBuffer := len(w.buf) - buffered
-		if toBuffer > len(p) {
-			toBuffer = len(p)
-		}
-
-		copied := copy(w.buf[buffered:], p[:toBuffer])
-		p = p[copied:]
-		w.len += int64(copied)
-
-		if copied > 0 && w.len%int64(len(w.buf)) == 0 {
-			leaf := make(chan ciderr, 1)
-			bufIdx := <-w.throttle
-			copy(w.tbufs[bufIdx][:], w.buf[:])
-
-			go func() {
-				defer func() {
-					w.throttle <- bufIdx
-				}()
-
-				cc := new(commp.Calc)
-				_, _ = cc.Write(w.tbufs[bufIdx][:])
-				p, _, _ := cc.Digest()
-				l, _ := commcid.PieceCommitmentV1ToCID(p)
-				leaf <- ciderr{
-					c:   l,
-					err: nil,
-				}
-			}()
-
-			w.leaves = append(w.leaves, leaf)
-		}
-	}
-	return n, nil
-}
-
-func (w *DataCidWriter) Sum() (DataCIDSize, error) {
-	// process last non-zero leaf if exists
-	lastLen := w.len % int64(len(w.buf))
-	rawLen := w.len
-
-	leaves := make([]cid.Cid, len(w.leaves))
-	for i, leaf := range w.leaves {
-		r := <-leaf
-		if r.err != nil {
-			return DataCIDSize{}, xerrors.Errorf("processing leaf %d: %w", i, r.err)
-		}
-		leaves[i] = r.c
-	}
-
-	// process remaining bit of data
-	if lastLen != 0 {
-		if len(leaves) != 0 {
-			copy(w.buf[lastLen:], make([]byte, int(int64(CommPBuf)-lastLen)))
-			lastLen = int64(CommPBuf)
-		}
-
-		cc := new(commp.Calc)
-		_, _ = cc.Write(w.buf[:lastLen])
-		pb, pps, _ := cc.Digest()
-		p, _ := commcid.PieceCommitmentV1ToCID(pb)
-
-		if abi.PaddedPieceSize(pps).Unpadded() < CommPBuf { // special case for pieces smaller than 16MiB
-			return DataCIDSize{
-				PayloadSize: w.len,
-				PieceSize:   abi.PaddedPieceSize(pps),
-				PieceCID:    p,
-			}, nil
-		}
-
-		leaves = append(leaves, p)
-	}
-
-	// pad with zero pieces to power-of-two size
-	fillerLeaves := (1 << (bits.Len(uint(len(leaves) - 1)))) - len(leaves)
-	for i := 0; i < fillerLeaves; i++ {
-		leaves = append(leaves, zerocomm.ZeroPieceCommitment(CommPBuf))
-	}
-
-	if len(leaves) == 1 {
-		return DataCIDSize{
-			PayloadSize: rawLen,
-			PieceSize:   abi.PaddedPieceSize(len(leaves)) * commPBufPad,
-			PieceCID:    leaves[0],
-		}, nil
-	}
-
-	pieces := make([]abi.PieceInfo, len(leaves))
-	for i, leaf := range leaves {
-		pieces[i] = abi.PieceInfo{
-			Size:     commPBufPad,
-			PieceCID: leaf,
-		}
-	}
-
-	p, err := nonffi.GenerateUnsealedCID(abi.RegisteredSealProof_StackedDrg32GiBV1, pieces)
-	if err != nil {
-		return DataCIDSize{}, xerrors.Errorf("generating unsealed CID: %w", err)
-	}
-
-	return DataCIDSize{
-		PayloadSize: rawLen,
-		PieceSize:   abi.PaddedPieceSize(len(leaves)) * commPBufPad,
-		PieceCID:    p,
-	}, nil
 }


### PR DESCRIPTION
Thought it was cleaner to use a library with the same code.

The commp calculation works, but getting a weird error from ffi logger that I still need to debug.

```
anjor@seven car-generation-testing $ ~/repos/application-research/delta/delta commp --file 1G-payload.bin
[flexi_logger][ERRCODE::Time] flexi_logger has to work with UTC rather than with local time, caused by IndeterminateOffset
    See https://docs.rs/flexi_logger/latest/flexi_logger/error_info/index.html#time
{
    "wallet": {},
    "piece_commitment": {
        "piece_cid": "baga6ea4seaqplsqtephzafwqb7vn7dmwfr5yavv2yxgi72ping4g2b6otk6f2oa",
        "padded_piece_size": 2147483648,
        "unpadded_piece_size": 2130706432
    },
    "connection_mode": "e2e",
    "size": 1073741824
}

```