### PR TITLE
feat: use short commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL=/usr/bin/env bash
 GO_BUILD_IMAGE?=golang:1.19
 VERSION=$(shell git describe --always --tag --dirty)
+COMMIT=$(shell git rev-parse --short HEAD)
 
 .PHONY: all
 all: build
@@ -10,7 +11,7 @@ build:
 	git submodule update --init --recursive
 	make -C extern/filecoin-ffi
 	go generate
-	go build -tags netgo -ldflags="-s -w -X main.Commit=$(shell git rev-parse HEAD) -X main.Version=$(VERSION)" -o delta
+	go build -tags netgo -ldflags="-s -w -X main.Commit=$(COMMIT) -X main.Version=$(VERSION)" -o delta
 
 .PHONE: clean
 clean:


### PR DESCRIPTION
- Use short commit hash for node info, as it's easier to display and standard with other version commands (i.e, `lotus version`) 