### PR TITLE
feat: retry a content id

### DIFF
--- a/api/repair.go
+++ b/api/repair.go
@@ -28,6 +28,7 @@ func ConfigureRepairRouter(e *echo.Group, node *core.DeltaNode) {
 
 func handleRetryContent(node *core.DeltaNode) func(c echo.Context) error {
 	return func(c echo.Context) error {
+
 		var contentId = c.Param("contentId")
 
 		// look up the content

--- a/docs/repair.md
+++ b/docs/repair.md
@@ -3,6 +3,13 @@
 Delta has built-in repair and retry functionality. This is useful for when a storage deal fails for some reason. The repair and retry functionality is built into the daemon and can be accessed thru HTTP API.
 
 ## Repair/retry
+### Retry a deal for a content
+```
+curl --location --request GET 'http://localhost:1414/api/v1/retry/deal/:contentId' \
+--header 'Authorization: Bearer [API_KEY]' \
+--header 'Content-Type: application/json' 
+```
+
 ### Repair or retry a deal for a content
 ```
 curl --location --request GET 'http://localhost:1414/api/v1/repair/deal/content/:contentId' \
@@ -16,3 +23,4 @@ curl --location --request GET 'http://localhost:1414/api/v1/repair/deal/piece-co
 --header --header 'Authorization: Bearer [API_KEY]' \
 --header 'Content-Type: application/json' 
 ```
+


### PR DESCRIPTION
# Changes
- allow the user to retry a specific content id. The process will re-create the same deal request of the content id and push it thru the dispatcher for processing.
- it returns the new content id that can be used to check the status.