### PR TITLE
feat: expose label and verified deal param

### DIFF
--- a/api/deal.go
+++ b/api/deal.go
@@ -839,7 +839,7 @@ func handleEndToEndDeal(c echo.Context, node *core.DeltaNode) error {
 			startEpochTime := time.Now().AddDate(0, 0, int(dealRequest.StartEpochInDays))
 			dealRequest.StartEpoch = utils.DateToHeight(startEpochTime)
 			dealRequest.StartEpoch = dealRequest.StartEpoch + (utils.EPOCH_PER_HOUR * 24 * 7)
-			dealProposalParam.StartEpoch = dealRequest.StartEpoch
+			//dealProposalParam.StartEpoch = dealRequest.StartEpoch
 		}
 
 		if dealRequest.DurationInDays > 540 {
@@ -1056,8 +1056,10 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 		if dealRequest.StartEpochInDays != 0 {
 			startEpochTime := time.Now().AddDate(0, 0, int(dealRequest.StartEpochInDays))
 			dealRequest.StartEpoch = utils.DateToHeight(startEpochTime)
-			dealRequest.StartEpoch = dealRequest.StartEpoch + (utils.EPOCH_PER_HOUR * 24 * 7)
-			dealProposalParam.StartEpoch = dealRequest.StartEpoch
+			//dealStart := head.Height() + (epochsPerHour * 24 * 7)
+			//dealRequest.StartEpoch = dealRequest.StartEpoch + (utils.EPOCH_PER_HOUR * 24 * 7)
+			dealRequest.StartEpoch = dealRequest.StartEpoch + (utils.EPOCH_PER_HOUR * 24 * (7 - dealRequest.StartEpochInDays))
+			//dealProposalParam.StartEpoch = dealRequest.StartEpoch
 		}
 
 		if dealRequest.DurationInDays > 540 {
@@ -1280,7 +1282,7 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 				startEpochTime := time.Now().AddDate(0, 0, int(dealRequest.StartEpochInDays))
 				dealRequest.StartEpoch = utils.DateToHeight(startEpochTime)
 				dealRequest.StartEpoch = dealRequest.StartEpoch + (utils.EPOCH_PER_HOUR * 24 * 7)
-				dealProposalParam.StartEpoch = dealRequest.StartEpoch
+				//dealProposalParam.StartEpoch = dealRequest.StartEpoch
 			}
 
 			if dealRequest.DurationInDays > 540 {
@@ -1310,7 +1312,7 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 
 			dealResponses = append(dealResponses, DealResponse{
 				Status:                       "success",
-				Message:                      "Deal request received. Please take note of the content_id",
+				Message:                      "Deal request received. Please take note of the content_id. You can use the content_id to check the status of the deal.",
 				ContentId:                    content.ID,
 				DealRequest:                  dealRequest,
 				DealProposalParameterRequest: dealProposalParam,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -248,7 +248,7 @@ Take note of the content_id. You'll use this to get the status of the deal.
         },
         "connection_mode": "import",
         "size": 18010019221,
-        "remove_unsealed_copies": true,
+        "remove_unsealed_copy": true,
         "skip_ipni_announce": true,
         "duration_in_days": 537,
         "start_epoch_at_days": 3
@@ -273,7 +273,7 @@ Take note of all the content_ids.
                 "padded_piece_size": 34359738368,
                 "piece_cid": "baga6ea4seaqblmkqfesvijszk34r3j6oairnl4fhi2ehamt7f3knn3gwkyylmlq"
             },
-            "remove_unsealed_copies": true,
+            "remove_unsealed_copy": true,
             "size": 18010019221,
             "skip_ipni_announce": true,
             "start_epoch": 2742000,

--- a/docs/deal-metadata.md
+++ b/docs/deal-metadata.md
@@ -35,6 +35,8 @@ The `skip_ipni_announce` field is a boolean field that indicates whether to skip
 - The `start_epoch` field is the epoch to start the deal. This is optional.
 # deal_verify_state
 The `deal_verify_state` field is the state of the deal verification. This is to indicate if the deal is from verified FIL or not. This is optional.
+
+valid values are: `verified`, `unverified`. Default: `verified`.
 # label
 The `label` field is a label for the deal. It has a limit of less than 100 characters. This is optional.
 

--- a/docs/deal-metadata.md
+++ b/docs/deal-metadata.md
@@ -33,7 +33,10 @@ The `skip_ipni_announce` field is a boolean field that indicates whether to skip
 # start_epoch_at_days or start_epoch
 - The `start_epoch_at_days` field is the epoch to start the deal. This is optional.
 - The `start_epoch` field is the epoch to start the deal. This is optional.
-
+# deal_verify_state
+The `deal_verify_state` field is the state of the deal verification. This is to indicate if the deal is from verified FIL or not. This is optional.
+# label
+The `label` field is a label for the deal. It has a limit of less than 100 characters. This is optional.
 
 # Here's the complete structure of the `metadata` request.
 ```

--- a/docs/deal-metadata.md
+++ b/docs/deal-metadata.md
@@ -23,8 +23,8 @@ The `unpadded_piece_size` field is the unpadded piece size of the content to be 
 The `connection_mode` field is the connection mode to use to make the deal. This is either `e2e` or `import`. This is required.
 # size
 The `size` field is the size of the content to be stored. This is only required if the `connection_mode` is `import`. If the `connection_mode` is `e2e`, then the `size` field is not required.
-# remove_unsealed_copies
-The `remove_unsealed_copies` field is a boolean field that indicates whether to remove unsealed copies of the content after the deal is made. This is optional. 
+# remove_unsealed_copy
+The `remove_unsealed_copy` field is a boolean field that indicates whether to remove unsealed copies of the content after the deal is made. This is optional. 
 # skip_ipni_announce
 The `skip_ipni_announce` field is a boolean field that indicates whether to skip announcing the deal to interplanetary indexer. This is optional. 
 # duration_in_days or duration
@@ -54,7 +54,7 @@ The `label` field is a label for the deal. It has a limit of less than 100 chara
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true,
     "duration_in_days": 540, 
     // OR "duration": "1555200" // duration in epochs (30 seconds)

--- a/docs/deal-metadata.md
+++ b/docs/deal-metadata.md
@@ -27,15 +27,12 @@ The `size` field is the size of the content to be stored. This is only required 
 The `remove_unsealed_copy` field is a boolean field that indicates whether to remove unsealed copies of the content after the deal is made. This is optional. 
 # skip_ipni_announce
 The `skip_ipni_announce` field is a boolean field that indicates whether to skip announcing the deal to interplanetary indexer. This is optional. 
-# duration_in_days or duration
-- The `duration_in_days` field is the duration of the deal in days. This is optional. 
-- The `duration` field is the duration of the deal in epochs. This is optional. 
-# start_epoch_at_days or start_epoch
+# duration_in_days
+- The `duration_in_days` field is the duration of the deal in days. This is optional.
+# start_epoch_in_days
 - The `start_epoch_at_days` field is the epoch to start the deal. This is optional.
-- The `start_epoch` field is the epoch to start the deal. This is optional.
 # deal_verify_state
 The `deal_verify_state` field is the state of the deal verification. This is to indicate if the deal is from verified FIL or not. This is optional.
-
 valid values are: `verified`, `unverified`. Default: `verified`.
 # label
 The `label` field is a label for the deal. It has a limit of less than 100 characters. This is optional.
@@ -57,9 +54,7 @@ The `label` field is a label for the deal. It has a limit of less than 100 chara
     "remove_unsealed_copy":true, 
     "skip_ipni_announce": true,
     "duration_in_days": 540, 
-    // OR "duration": "1555200" // duration in epochs (30 seconds)
-    "start_epoch_at_days": 14, // days to delay before the deal starts
-    // OR "start_epoch": 2729999 // epoch at which to start the deal - see https://www.epochclock.io/
+    "start_epoch_in_days": 14, // days to delay before the deal starts
 }
 ```
 

--- a/docs/getting-started-use-delta.md
+++ b/docs/getting-started-use-delta.md
@@ -37,7 +37,7 @@ Here's the complete structure of the `metadata` request.
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true
 }
 ```
@@ -93,7 +93,7 @@ curl --location --request POST 'http://localhost:1414/api/v1/deal/imports' \
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true
 }]'
 ```
@@ -128,7 +128,7 @@ The response will look like this:
             "size": 18010019221,
             "start_epoch": 2730480,
             "start_epoch_at_days": 3,
-            "remove_unsealed_copies": true,
+            "remove_unsealed_copy": true,
             "skip_ipni_announce": true
         }
     }
@@ -179,7 +179,7 @@ Once a wallet is registered, we can add a `wallet` field to the `metadata` reque
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true
 }
 ```

--- a/docs/make-e2e-deal.md
+++ b/docs/make-e2e-deal.md
@@ -35,7 +35,7 @@ Here's the complete structure of the `metadata` request.
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true,
     "duration_in_days": 537,
     "start_epoch_at_days": 3

--- a/docs/make-import-deal.md
+++ b/docs/make-import-deal.md
@@ -37,7 +37,7 @@ Here's the complete structure of the `metadata` request.
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true
 }
 ```
@@ -58,7 +58,7 @@ curl --location --request POST 'http://localhost:1414/api/v1/deal/imports' \
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true
 }]'
 ```
@@ -93,7 +93,7 @@ The response will look like this:
             "size": 18010019221,
             "start_epoch": 2730480,
             "start_epoch_at_days": 3,
-            "remove_unsealed_copies": true,
+            "remove_unsealed_copy": true,
             "skip_ipni_announce": true
         }
     }
@@ -144,7 +144,7 @@ Once a wallet is registered, we can add a `wallet` field to the `metadata` reque
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true
 }
 ```

--- a/docs/manage-wallets.md
+++ b/docs/manage-wallets.md
@@ -40,7 +40,7 @@ Once a wallet is registered, we can add a `wallet` field to the `metadata` reque
     },
     "connection_mode": "import",
     "size": 2500366291,
-    "remove_unsealed_copies":true, 
+    "remove_unsealed_copy":true, 
     "skip_ipni_announce": true
 }
 ```

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a
-	github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9
+	github.com/application-research/filclient v0.5.0-rc1.0.20230331195738-9826f79f0648
 	github.com/application-research/whypfs-core v0.1.1
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/filecoin-project/boost v1.5.1-rc5

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
-	github.com/application-research/delta-db v0.0.2-0.20230328110913-3c40abd40579
+	github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a
 	github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9
 	github.com/application-research/whypfs-core v0.1.1
 	github.com/caarlos0/env/v6 v6.10.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
-	github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a
+	github.com/application-research/delta-db v0.0.2-0.20230401000636-2487780d048f
 	github.com/application-research/filclient v0.5.0-rc1.0.20230331195738-9826f79f0648
 	github.com/application-research/whypfs-core v0.1.1
 	github.com/caarlos0/env/v6 v6.10.1

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a h1:bwSF2Loga3h7VZ/OlPhrtb7tCGEqxeD9BvBWjgpWgDM=
 github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
+github.com/application-research/delta-db v0.0.2-0.20230401000636-2487780d048f h1:9nS8kCSuJp2NtpS9/f1jYxeQ2H+ifXqv4QUpObfS20s=
+github.com/application-research/delta-db v0.0.2-0.20230401000636-2487780d048f/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
 github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9 h1:x60eXkdBR8JkyFaxQYsep0cEo7HfwzxrkZ5H5YaYvmk=
 github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9/go.mod h1:QI5TGGs8M43kdVOqOshBLqRwMwnAgdcSODgtyIeQE4o=
 github.com/application-research/filclient v0.5.0-rc1.0.20230331185752-d7bef250645c h1:jcUgGtuQHDEyrmQSwNjkVzQO6cm2W+yxvot+IWyZQw4=

--- a/go.sum
+++ b/go.sum
@@ -86,10 +86,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/application-research/delta-db v0.0.2-0.20230322102216-fe7920b79230 h1:/PLLD+iP5FUPyrCkLUbC03hqd/7xzRYK/Y1ucGEW/jo=
-github.com/application-research/delta-db v0.0.2-0.20230322102216-fe7920b79230/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
-github.com/application-research/delta-db v0.0.2-0.20230328110913-3c40abd40579 h1:0AlckKn+KwGDcSC32UxvS1fjLkmVNoRlLgnToI6aESw=
-github.com/application-research/delta-db v0.0.2-0.20230328110913-3c40abd40579/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
+github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a h1:bwSF2Loga3h7VZ/OlPhrtb7tCGEqxeD9BvBWjgpWgDM=
+github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
 github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9 h1:x60eXkdBR8JkyFaxQYsep0cEo7HfwzxrkZ5H5YaYvmk=
 github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9/go.mod h1:QI5TGGs8M43kdVOqOshBLqRwMwnAgdcSODgtyIeQE4o=
 github.com/application-research/whypfs-core v0.1.1 h1:BY40N15Ge9BlyAT3f4T4B/CAlaL7A1RYaRrNS3HIyEk=

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,12 @@ github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a h1
 github.com/application-research/delta-db v0.0.2-0.20230330232216-a2278c35365a/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
 github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9 h1:x60eXkdBR8JkyFaxQYsep0cEo7HfwzxrkZ5H5YaYvmk=
 github.com/application-research/filclient v0.5.0-rc1.0.20230223164100-9a428cb812a9/go.mod h1:QI5TGGs8M43kdVOqOshBLqRwMwnAgdcSODgtyIeQE4o=
+github.com/application-research/filclient v0.5.0-rc1.0.20230331185752-d7bef250645c h1:jcUgGtuQHDEyrmQSwNjkVzQO6cm2W+yxvot+IWyZQw4=
+github.com/application-research/filclient v0.5.0-rc1.0.20230331185752-d7bef250645c/go.mod h1:HSCZh+v53XTGMwHGyoKpedQH+PlwcmKkMFCYx/Q3hMk=
+github.com/application-research/filclient v0.5.0-rc1.0.20230331191850-e77cfd883d40 h1:iPUrZJseUlZEqlBeWvL5xfYiGmP1d3RTJjfC6VxiazE=
+github.com/application-research/filclient v0.5.0-rc1.0.20230331191850-e77cfd883d40/go.mod h1:HSCZh+v53XTGMwHGyoKpedQH+PlwcmKkMFCYx/Q3hMk=
+github.com/application-research/filclient v0.5.0-rc1.0.20230331195738-9826f79f0648 h1:58+odb1yvlrhuWbmpcAu7IKN4/0+LOP8XjKP3JxOPGo=
+github.com/application-research/filclient v0.5.0-rc1.0.20230331195738-9826f79f0648/go.mod h1:HSCZh+v53XTGMwHGyoKpedQH+PlwcmKkMFCYx/Q3hMk=
 github.com/application-research/whypfs-core v0.1.1 h1:BY40N15Ge9BlyAT3f4T4B/CAlaL7A1RYaRrNS3HIyEk=
 github.com/application-research/whypfs-core v0.1.1/go.mod h1:WPKze2Lt1+gC389Uvsr+MSqvSmqShoQbtl0/RzNC2r0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/jobs/storage_deal_maker.go
+++ b/jobs/storage_deal_maker.go
@@ -177,6 +177,10 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 		dealProp.Proposal.StartEpoch = abi.ChainEpoch(dealProposal.StartEpoch)
 	}
 
+	if dealProposal.EndEpoch != 0 {
+		dealProp.Proposal.EndEpoch = abi.ChainEpoch(dealProposal.EndEpoch)
+	}
+
 	propnd, err := cborutil.AsIpld(dealProp)
 	if err != nil {
 		i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{

--- a/jobs/storage_deal_maker.go
+++ b/jobs/storage_deal_maker.go
@@ -153,6 +153,9 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 		fc.DealWithVerified(dealProposal.VerifiedDeal),
 		fc.DealWithFastRetrieval(!dealProposal.RemoveUnsealedCopy),
 		fc.DealWithLabel(label),
+		fc.DealWithStartEpoch(abi.ChainEpoch(dealProposal.StartEpoch)),
+		fc.DealWithEndEpoch(abi.ChainEpoch(dealProposal.EndEpoch)),
+		fc.DealWithPricePerEpoch(priceBigInt),
 		fc.DealWithPieceInfo(fc.DealPieceInfo{
 			Cid:         pieceCid,
 			Size:        abi.PaddedPieceSize(pieceComm.PaddedPieceSize),
@@ -243,164 +246,55 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 	}
 
 	// check proposal phase if true and if there are any errors
-	if propPhase == true && err != nil {
-		if strings.Contains(err.Error(), "failed to send request: stream reset") {
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
+	if propPhase && err != nil {
+		toUpdate := model.ContentDeal{
+			LastMessage: err.Error(),
+			Failed:      true,
+			UpdatedAt:   time.Now(),
+		}
+		switch {
+		case strings.Contains(err.Error(), "failed to send request: stream reset"):
+			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(&toUpdate)
+			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).
+				Updates(model.Content{
+					Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED,
+					LastMessage: err.Error(),
+					UpdatedAt:   time.Now(),
+				})
 			return nil
-		}
-
-		if strings.Contains(err.Error(), "deal proposal rejected") {
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
-			return nil
-		}
-
-		if strings.Contains(err.Error(), "deal proposal is identical") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
+		case strings.Contains(err.Error(), "deal proposal rejected"), strings.Contains(err.Error(), "deal duration out of bounds"),
+			strings.Contains(err.Error(), "invalid deal end epoch"), strings.Contains(err.Error(), "could not load link"),
+			strings.Contains(err.Error(), "proposal PieceCID had wrong prefix"), strings.Contains(err.Error(), "proposal piece size is invalid"):
+			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(&toUpdate)
+			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).
+				Updates(model.Content{
+					Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED,
+					LastMessage: err.Error(),
+					UpdatedAt:   time.Now(),
+				})
 			return err
-		}
-
-		if strings.Contains(err.Error(), "deal duration out of bounds") {
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
+		case strings.Contains(err.Error(), "storage price per epoch less than asking price"):
+			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(&toUpdate)
+			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).
+				Updates(model.Content{
+					Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED,
+					LastMessage: err.Error(),
+				})
 			return err
-		}
-
-		if strings.Contains(err.Error(), "storage price per epoch less than asking price") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-			})
+		case strings.Contains(err.Error(), "piece size less than minimum required size"), strings.Contains(err.Error(), "send proposal rpc:"):
+			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(&toUpdate)
+			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).
+				Updates(model.Content{
+					Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED,
+					LastMessage: err.Error(),
+					UpdatedAt:   time.Now(),
+				})
+			i.LightNode.Dispatcher.AddJobAndDispatch(NewStorageDealMakerProcessor(i.LightNode, *content, *pieceComm), 1)
 			return err
-		}
-		if strings.Contains(err.Error(), " piece size less than minimum required size") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
-			return err
-		}
-
-		if strings.Contains(err.Error(), " invalid deal end epoch") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
-			return err
-		}
-
-		if strings.Contains(err.Error(), "could not load link") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
-			return err
-		}
-
-		if strings.Contains(err.Error(), "proposal PieceCID had wrong prefix") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-			})
-			return err
-		}
-
-		if strings.Contains(err.Error(), "proposal piece size is invalid") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
-			return err
-		}
-
-		if strings.Contains(err.Error(), "send proposal rpc:") { // don't put it back on the queue
-			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(model.ContentDeal{
-				LastMessage: err.Error(),
-				Failed:      true, // mark it as failed
-				UpdatedAt:   time.Now(),
-			})
-			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(model.Content{
-				Status:      utils.CONTENT_DEAL_PROPOSAL_FAILED, //"failed",
-				LastMessage: err.Error(),
-				UpdatedAt:   time.Now(),
-			})
-			//	retry
+		default:
 			i.LightNode.Dispatcher.AddJobAndDispatch(NewStorageDealMakerProcessor(i.LightNode, *content, *pieceComm), 1)
 			return err
 		}
-
-		i.LightNode.Dispatcher.AddJobAndDispatch(NewStorageDealMakerProcessor(i.LightNode, *content, *pieceComm), 1)
-
-		return err
 	}
 
 	// if we are here, we have a deal proposal but with errors.

--- a/jobs/storage_deal_maker.go
+++ b/jobs/storage_deal_maker.go
@@ -150,7 +150,7 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 	}
 
 	prop, err := filClient.MakeDealWithOptions(i.Context, minerAddress, payloadCid, priceBigInt, duration,
-		fc.DealWithVerified(true),
+		fc.DealWithVerified(dealProposal.VerifiedDeal),
 		fc.DealWithFastRetrieval(!dealProposal.RemoveUnsealedCopy),
 		fc.DealWithLabel(label),
 		fc.DealWithPieceInfo(fc.DealPieceInfo{

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -1,3 +1,4 @@
+// A package that is used to define the constants used in the project.
 package utils
 
 import "github.com/application-research/delta-db/messaging"
@@ -53,5 +54,6 @@ const (
 	DEFAULT_DURATION            = EPOCH_540_DAYS - (EPOCH_PER_DAY * 21)
 
 	COMMP_MODE_FAST     = "fast"
+	COMMP_MODE_STREAM   = "stream"
 	COMPP_MODE_FILBOOST = "filboost"
 )

--- a/utils/constants.go
+++ b/utils/constants.go
@@ -40,6 +40,9 @@ const (
 	CONNECTION_MODE_E2E    = "e2e"
 	CONNECTION_MODE_IMPORT = "import"
 
+	DEAL_VERIFIED   = "verified"
+	DEAL_UNVERIFIED = "unverified"
+
 	LOTUS_API = "http://api.chain.love"
 	API_AUTH  = "https://auth.estuary.tech/check-api-key"
 


### PR DESCRIPTION
# Changes 

Added the following fields to the metadata spec

- `label` - users can now put a custom 100 character string to label their deal
- `deal_verify_state` - this is to indicate that the deal is from or will be transacted using a verified FIL (fil+) - default is "verified". Option: "unverified".
