### PR TITLE
feat: fixed the repair and retry functionality

### DIFF
--- a/api/deal.go
+++ b/api/deal.go
@@ -1352,10 +1352,10 @@ func ValidateMeta(dealRequest DealRequest) error {
 		return errors.New("label length must be less than 100")
 	}
 
-	if (DealRequest{} != dealRequest && dealRequest.DealVerifyState == "") {
-		dealRequest.DealVerifyState = utils.DEAL_VERIFIED
-	} else if (DealRequest{} != dealRequest && dealRequest.DealVerifyState != utils.DEAL_VERIFIED) {
+	if (DealRequest{} != dealRequest && dealRequest.DealVerifyState == utils.DEAL_UNVERIFIED) {
 		dealRequest.DealVerifyState = utils.DEAL_UNVERIFIED
+	} else {
+		dealRequest.DealVerifyState = utils.DEAL_VERIFIED
 	}
 
 	// connection mode is required

--- a/api/openstats.go
+++ b/api/openstats.go
@@ -79,17 +79,6 @@ func handleOpenGetDealsWithPaging(c echo.Context, node *core.DeltaNode) error {
 
 	// get deals
 	var deals []model.ContentDeal
-	// select * from content_deals c where
-	//c.id in (select id from content_deals group by content order by content desc) order by id desc;
-
-	//SELECT c1.*
-	//	FROM content_deals c1
-	//JOIN (
-	//	SELECT MAX(id) AS max_id, content
-	//FROM content_deals
-	//GROUP BY content
-	//) c2 ON c1.id = c2.max_id
-	//ORDER BY c1.id DESC;
 	node.DB.Raw("SELECT c1.* FROM content_deals c1 JOIN ( SELECT MAX(id) AS max_id, content FROM content_deals GROUP BY content ) c2 ON c1.id = c2.max_id ORDER BY c1.id DESC").Limit(pageSize).Offset((page - 1) * pageSize).Find(&deals)
 
 	return c.JSON(200, map[string]interface{}{

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -43,14 +43,30 @@ func DaemonCmd(cfg *c.DeltaConfig) []*cli.Command {
 				Name:  "mode",
 				Usage: "standalone or cluster mode",
 			},
-
 			&cli.StringFlag{
+				Name:  "commp-mode",
+				Usage: "standalone or cluster mode",
+				Value: utils.COMPP_MODE_FILBOOST,
+			},
+			&cli.BoolFlag{
 				Name:  "enable-websocket",
 				Usage: "enable websocket or not",
+				Value: false,
 			},
-			&cli.StringFlag{
+			&cli.BoolFlag{
 				Name:  "stats-collection",
 				Usage: "enable stats collection or not",
+				Value: true,
+			},
+			&cli.BoolFlag{
+				Name:  "keep-copies",
+				Usage: "keep copies of the data or not",
+				Value: false,
+			},
+			&cli.BoolFlag{
+				Name:  "miner-throttle",
+				Usage: "enable miner throttle or not",
+				Value: false,
 			},
 		},
 
@@ -69,8 +85,8 @@ func DaemonCmd(cfg *c.DeltaConfig) []*cli.Command {
 			repo := c.String("repo")
 			walletDir := c.String("wallet-dir")
 			mode := c.String("mode")
-			enableWebsocket := c.String("enable-websocket")
-			statsCollection := c.String("stats-collection")
+			enableWebsocket := c.Bool("enable-websocket")
+			statsCollection := c.Bool("stats-collection")
 			commpMode := c.String("commp-mode")
 
 			if repo == "" {
@@ -87,23 +103,9 @@ func DaemonCmd(cfg *c.DeltaConfig) []*cli.Command {
 				cfg.Common.Mode = mode
 			}
 
-			if enableWebsocket == "" {
-				cfg.Common.EnableWebsocket = false
-			} else {
-				cfg.Common.EnableWebsocket = true
-			}
-
-			if statsCollection == "" {
-				cfg.Common.StatsCollection = true
-			} else {
-				cfg.Common.StatsCollection = false
-			}
-
-			if commpMode == "" {
-				cfg.Common.CommpMode = utils.COMPP_MODE_FILBOOST
-			} else {
-				cfg.Common.CommpMode = commpMode
-			}
+			cfg.Common.EnableWebsocket = enableWebsocket
+			cfg.Common.StatsCollection = statsCollection
+			cfg.Common.CommpMode = commpMode
 
 			fmt.Println(utils.Blue + "Setting up the whypfs node... " + utils.Reset)
 			fmt.Println("repo: ", utils.Purple+repo+utils.Reset)

--- a/cmd/deal.go
+++ b/cmd/deal.go
@@ -26,231 +26,265 @@ func DealCmd(cfg *c.DeltaConfig) []*cli.Command {
 		Name:        "deal",
 		Usage:       "Make a Network Storage Deal on Delta",
 		Description: "Make a delta storage deal. The type of deal can be either e2e (online) or import (offline).",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "type",
-				Usage: "e2e (online) or import (offline)",
-			},
-			&cli.StringFlag{
-				Name:  "file",
-				Usage: "file to make a deal with. Required only for e2e deals.",
-			},
-			&cli.StringFlag{
-				Name:  "metadata",
-				Usage: "metadata to store",
-			},
-		},
-		Action: func(context *cli.Context) error {
-			cmd, err := NewDeltaCmdNode(context)
-			if err != nil {
-				return err
-			}
-
-			fileParam := context.String("file")
-			typeParam := context.String("type")
-			metadataParam := context.String("metadata")
-			var metadata DealMetadata
-			var metadataArr []DealMetadata
-			var e2eResponse DealResponse
-			var importResponse []DealResponse
-
-			// validate
-			if typeParam == "e2e" {
-				if fileParam == "" {
-					fmt.Println("file is required for e2e deals")
-					os.Exit(1)
-				}
-			}
-			if metadataParam == "" {
-				fmt.Println("metadata is required")
-				os.Exit(1)
-			}
-
-			if typeParam == "import" {
-				if fileParam != "" {
-					fmt.Println("file is not required for import deals")
-					os.Exit(1)
-				}
-			}
-
-			var endpoint string
-			url := cmd.DeltaApi + "/api/v1"
-			if typeParam == "e2e" {
-
-				err := json.Unmarshal([]byte(metadataParam), &metadata)
-				if err != nil {
-					var buffer bytes.Buffer
-					err = utils.PrettyEncode(DealResponse{
-						Status:  "error",
-						Message: "Error unmarshalling metadata",
-					}, &buffer)
+		Subcommands: []*cli.Command{
+			{
+				Name:  "make",
+				Usage: "Make a delta storage deal",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "type",
+						Usage: "e2e (online) or import (offline)",
+					},
+					&cli.StringFlag{
+						Name:  "file",
+						Usage: "file to make a deal with. Required only for e2e deals.",
+					},
+					&cli.StringFlag{
+						Name:  "metadata",
+						Usage: "metadata to store",
+					},
+				},
+				Action: func(context *cli.Context) error {
+					cmd, err := NewDeltaCmdNode(context)
 					if err != nil {
-						fmt.Println(err)
+						return err
 					}
-					fmt.Println(buffer.String())
-				}
 
-				endpoint = url + "/deal/end-to-end"
+					fileParam := context.String("file")
+					typeParam := context.String("type")
+					metadataParam := context.String("metadata")
+					var metadata DealMetadata
+					var metadataArr []DealMetadata
+					var e2eResponse DealResponse
+					var importResponse []DealResponse
 
-				// Create a new HTTP request with the desired method and URL.
-				req, err := http.NewRequest("POST", endpoint, nil)
-				if err != nil {
-					panic(err)
-				}
-
-				// Set the Authorization header.
-				req.Header.Set("Authorization", "Bearer "+cmd.DeltaAuth)
-
-				// Create a new multipart writer for the request body.
-				body := &bytes.Buffer{}
-				writer := multipart.NewWriter(body)
-
-				// Add the data file to the multipart writer.
-				file, err := os.Open(fileParam)
-				if err != nil {
-					panic(err)
-				}
-
-				part, err := writer.CreateFormFile("data", file.Name())
-				if err != nil {
-					panic(err)
-				}
-				_, err = io.Copy(part, file)
-				if err != nil {
-					panic(err)
-				}
-
-				err = writer.WriteField("metadata", metadataParam)
-				if err != nil {
-					panic(err)
-				}
-
-				// Close the multipart writer.
-				err = writer.Close()
-				if err != nil {
-					panic(err)
-				}
-
-				// Set the content type header for the request.
-				req.Header.Set("Content-Type", writer.FormDataContentType())
-
-				// Set the request body to the multipart writer's buffer.
-				req.Body = io.NopCloser(body)
-
-				// Send the HTTP request and print the response.
-				resp, err := http.DefaultClient.Do(req)
-				if err != nil {
-					panic(err)
-				}
-				defer resp.Body.Close()
-
-				fmt.Println(resp.Status)
-				if resp.StatusCode != 200 {
-
-					errorResponse := struct {
-						Error struct {
-							Code    int    `json:"code"`
-							Reason  string `json:"reason"`
-							Details string `json:"details"`
+					// validate
+					if typeParam == "e2e" {
+						if fileParam == "" {
+							fmt.Println("file is required for e2e deals")
+							os.Exit(1)
 						}
-					}{}
-
-					err = json.NewDecoder(resp.Body).Decode(&errorResponse)
-					if err != nil {
-						fmt.Println(err)
+					}
+					if metadataParam == "" {
+						fmt.Println("metadata is required")
+						os.Exit(1)
 					}
 
-					var buffer bytes.Buffer
-					err = utils.PrettyEncode(errorResponse, &buffer)
-					if err != nil {
-						fmt.Println(err)
-					}
-					fmt.Println(buffer.String())
-					return nil
-				}
-				err = json.NewDecoder(resp.Body).Decode(&e2eResponse)
-				if err != nil {
-					panic(err)
-				}
-				var buffer bytes.Buffer
-				err = utils.PrettyEncode(e2eResponse, &buffer)
-				if err != nil {
-					fmt.Println(err)
-				}
-				fmt.Println(buffer.String())
-				return nil
-			}
-			if typeParam == "import" {
-
-				err := json.Unmarshal([]byte(metadataParam), &metadataArr)
-				if err != nil {
-					var buffer bytes.Buffer
-					err = utils.PrettyEncode(DealResponse{
-						Status:  "error",
-						Message: "Error unmarshalling metadata",
-					}, &buffer)
-					if err != nil {
-						fmt.Println(err)
-					}
-					fmt.Println(buffer.String())
-				}
-				endpoint = url + "/deal/imports"
-
-				// Create a new HTTP request with the desired method and URL.
-				req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer([]byte(metadataParam)))
-				if err != nil {
-					panic(err)
-				}
-
-				// Set the Authorization and Content-Type headers.
-				req.Header.Set("Authorization", "Bearer "+cmd.DeltaAuth)
-				req.Header.Set("Content-Type", "application/json")
-
-				// Send the HTTP request and print the response.
-				resp, err := http.DefaultClient.Do(req)
-				if err != nil {
-					panic(err)
-				}
-				defer resp.Body.Close()
-
-				if resp.StatusCode != 200 {
-					errorResponse := struct {
-						Error struct {
-							Code    int    `json:"code"`
-							Reason  string `json:"reason"`
-							Details string `json:"details"`
+					if typeParam == "import" {
+						if fileParam != "" {
+							fmt.Println("file is not required for import deals")
+							os.Exit(1)
 						}
-					}{}
-
-					err = json.NewDecoder(resp.Body).Decode(&errorResponse)
-					if err != nil {
-						fmt.Println(err)
 					}
 
-					var buffer bytes.Buffer
-					err = utils.PrettyEncode(errorResponse, &buffer)
-					if err != nil {
-						fmt.Println(err)
+					var endpoint string
+					url := cmd.DeltaApi + "/api/v1"
+					if typeParam == "e2e" {
+
+						err := json.Unmarshal([]byte(metadataParam), &metadata)
+						if err != nil {
+							var buffer bytes.Buffer
+							err = utils.PrettyEncode(DealResponse{
+								Status:  "error",
+								Message: "Error unmarshalling metadata",
+							}, &buffer)
+							if err != nil {
+								fmt.Println(err)
+							}
+							fmt.Println(buffer.String())
+						}
+
+						endpoint = url + "/deal/end-to-end"
+
+						// Create a new HTTP request with the desired method and URL.
+						req, err := http.NewRequest("POST", endpoint, nil)
+						if err != nil {
+							panic(err)
+						}
+
+						// Set the Authorization header.
+						req.Header.Set("Authorization", "Bearer "+cmd.DeltaAuth)
+
+						// Create a new multipart writer for the request body.
+						body := &bytes.Buffer{}
+						writer := multipart.NewWriter(body)
+
+						// Add the data file to the multipart writer.
+						file, err := os.Open(fileParam)
+						if err != nil {
+							panic(err)
+						}
+
+						part, err := writer.CreateFormFile("data", file.Name())
+						if err != nil {
+							panic(err)
+						}
+						_, err = io.Copy(part, file)
+						if err != nil {
+							panic(err)
+						}
+
+						err = writer.WriteField("metadata", metadataParam)
+						if err != nil {
+							panic(err)
+						}
+
+						// Close the multipart writer.
+						err = writer.Close()
+						if err != nil {
+							panic(err)
+						}
+
+						// Set the content type header for the request.
+						req.Header.Set("Content-Type", writer.FormDataContentType())
+
+						// Set the request body to the multipart writer's buffer.
+						req.Body = io.NopCloser(body)
+
+						// Send the HTTP request and print the response.
+						resp, err := http.DefaultClient.Do(req)
+						if err != nil {
+							panic(err)
+						}
+						defer resp.Body.Close()
+
+						fmt.Println(resp.Status)
+						if resp.StatusCode != 200 {
+
+							errorResponse := struct {
+								Error struct {
+									Code    int    `json:"code"`
+									Reason  string `json:"reason"`
+									Details string `json:"details"`
+								}
+							}{}
+
+							err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+							if err != nil {
+								fmt.Println(err)
+							}
+
+							var buffer bytes.Buffer
+							err = utils.PrettyEncode(errorResponse, &buffer)
+							if err != nil {
+								fmt.Println(err)
+							}
+							fmt.Println(buffer.String())
+							return nil
+						}
+						err = json.NewDecoder(resp.Body).Decode(&e2eResponse)
+						if err != nil {
+							panic(err)
+						}
+						var buffer bytes.Buffer
+						err = utils.PrettyEncode(e2eResponse, &buffer)
+						if err != nil {
+							fmt.Println(err)
+						}
+						fmt.Println(buffer.String())
+						return nil
 					}
-					fmt.Println(buffer.String())
+					if typeParam == "import" {
+
+						err := json.Unmarshal([]byte(metadataParam), &metadataArr)
+						if err != nil {
+							var buffer bytes.Buffer
+							err = utils.PrettyEncode(DealResponse{
+								Status:  "error",
+								Message: "Error unmarshalling metadata",
+							}, &buffer)
+							if err != nil {
+								fmt.Println(err)
+							}
+							fmt.Println(buffer.String())
+						}
+						endpoint = url + "/deal/imports"
+
+						// Create a new HTTP request with the desired method and URL.
+						req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer([]byte(metadataParam)))
+						if err != nil {
+							panic(err)
+						}
+
+						// Set the Authorization and Content-Type headers.
+						req.Header.Set("Authorization", "Bearer "+cmd.DeltaAuth)
+						req.Header.Set("Content-Type", "application/json")
+
+						// Send the HTTP request and print the response.
+						resp, err := http.DefaultClient.Do(req)
+						if err != nil {
+							panic(err)
+						}
+						defer resp.Body.Close()
+
+						if resp.StatusCode != 200 {
+							errorResponse := struct {
+								Error struct {
+									Code    int    `json:"code"`
+									Reason  string `json:"reason"`
+									Details string `json:"details"`
+								}
+							}{}
+
+							err = json.NewDecoder(resp.Body).Decode(&errorResponse)
+							if err != nil {
+								fmt.Println(err)
+							}
+
+							var buffer bytes.Buffer
+							err = utils.PrettyEncode(errorResponse, &buffer)
+							if err != nil {
+								fmt.Println(err)
+							}
+							fmt.Println(buffer.String())
+							return nil
+						}
+						err = json.NewDecoder(resp.Body).Decode(&importResponse)
+						if err != nil {
+							panic(err)
+						}
+
+						// print output
+
+						var buffer bytes.Buffer
+						err = utils.PrettyEncode(importResponse, &buffer)
+						if err != nil {
+							fmt.Println(err)
+						}
+						fmt.Println(buffer.String())
+						return nil
+					}
 					return nil
-				}
-				err = json.NewDecoder(resp.Body).Decode(&importResponse)
-				if err != nil {
-					panic(err)
-				}
-
-				// print output
-
-				var buffer bytes.Buffer
-				err = utils.PrettyEncode(importResponse, &buffer)
-				if err != nil {
-					fmt.Println(err)
-				}
-				fmt.Println(buffer.String())
-				return nil
-			}
-			return nil
+				},
+			},
+			{
+				Name:  "repair",
+				Usage: "Repair a deal. This command is used to repair a deal that has been marked as failed. ",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "content-id",
+						Usage: "The content ID of the deal you want to repair",
+					},
+					&cli.StringFlag{},
+				},
+				Action: func(c *cli.Context) error {
+					return nil
+				},
+			},
+			{
+				Name:  "retry",
+				Usage: "Retry a deal. This command is used to retry a deal that has been marked as failed. ",
+				Flags: []cli.Flag{
+					&cli.StringFlag{
+						Name:  "content-id",
+						Usage: "The content ID of the deal you want to repair",
+					},
+					&cli.StringFlag{},
+				},
+				Action: func(c *cli.Context) error {
+					return nil
+				},
+			},
 		},
 	}
 	dealCommands = append(dealCommands, dealCmd)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,6 +8,7 @@ Delta CLI is packaged with the Delta node. Build and install `Delta` node as des
 - Car file generation cli
 - Piece commitment computation cli
 - Storage deal making cli
+- Storage deal repair and retry cli
 - Content status check cli
 - Wallet cli
 - SP / Miner selection cli
@@ -193,12 +194,12 @@ curl --location --request GET 'https://auth.estuary.tech/register-new-token'
 
 #### Make an E2E deal
 ```
-./delta deal --api-key=<API_KEY> --type=e2e --file=<> --metadata='{"miner":"f01963614","connection_mode":"e2e", "skip_ipni_announce":false}'
+./delta deal make --api-key=<API_KEY> --type=e2e --file=<> --metadata='{"miner":"f01963614","connection_mode":"e2e", "skip_ipni_announce":false}'
 ```
 
 Making a deal with a registered wallet
 ```
-./delta deal --api-key=<API_KEY> --type=e2e --file=<> --metadata='{"miner":"f01963614","connection_mode":"e2e", "skip_ipni_announce":false,"wallet":{"address":<address>}}'
+./delta deal make --api-key=<API_KEY> --type=e2e --file=<> --metadata='{"miner":"f01963614","connection_mode":"e2e", "skip_ipni_announce":false,"wallet":{"address":<address>}}'
 ```
 
 **Output**
@@ -230,7 +231,7 @@ Take note of the content_id. You'll use this to get the status of the deal.
 
 #### Make an Import deal
 ```
-./delta deal --api-key=<API_KEY> --type=import --metadata='[
+./delta deal make --api-key=<API_KEY> --type=import --metadata='[
     {
         "cid": "bafybeidylyizmuhqny6dj5vblzokmrmgyq5tocssps3nw3g22dnlty7bhy",
         "wallet": {

--- a/jobs/storage_deal_maker.go
+++ b/jobs/storage_deal_maker.go
@@ -482,7 +482,7 @@ func (i *StorageDealMakerProcessor) GetAssignedMinerForContent(content model.Con
 // Getting the content deal proposal parameters for a given content.
 func (i *StorageDealMakerProcessor) GetDealProposalForContent(content model.Content) (model.ContentDealProposalParameters, error) {
 	var contentDealProposalParameters model.ContentDealProposalParameters
-	err := i.LightNode.DB.Model(&model.ContentDealProposalParameters{}).Where("content = ?", content.ID).Find(&contentDealProposalParameters).Error
+	err := i.LightNode.DB.Model(&model.ContentDealProposalParameters{}).Where("content = ?", content.ID).Order("created_at desc").First(&contentDealProposalParameters).Error
 	if err != nil {
 		return model.ContentDealProposalParameters{}, err
 	}

--- a/jobs/storage_deal_maker.go
+++ b/jobs/storage_deal_maker.go
@@ -327,7 +327,6 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 		}
 		switch {
 		case strings.Contains(errProp.Error(), "failed to send request: stream reset"),
-			strings.Contains(errProp.Error(), "deal proposal rejected"),
 			strings.Contains(errProp.Error(), "proposal piece size is invalid"),
 			strings.Contains(errProp.Error(), "piece size less than minimum required size"),
 			strings.Contains(errProp.Error(), "storage price per epoch less than asking price"),
@@ -336,7 +335,7 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 			strings.Contains(errProp.Error(), "opening stream to miner: failed to open stream to peer: protocol not supported"),
 			strings.Contains(errProp.Error(), "miner is not considering online storage deals"),
 			strings.Contains(errProp.Error(), "send proposal rpc:"):
-			fmt.Println("failed to send proposal, re-assigning a miner")
+
 			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(&contentDealToUpdate)
 			i.LightNode.DB.Model(&content).Where("id = ?", content.ID).Updates(&contentToUpdate)
 
@@ -371,6 +370,7 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 			strings.Contains(errProp.Error(), "could not load link"),
 			strings.Contains(errProp.Error(), "failed validation: proposal end"),
 			strings.Contains(errProp.Error(), "failed to open stream to peer: protocol not supported"),
+			strings.Contains(errProp.Error(), "deal proposal is identical to deal"),
 			strings.Contains(errProp.Error(), "proposal PieceCID had wrong prefix"):
 			fmt.Println("case 2", errProp.Error())
 			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(&contentDealToUpdate)


### PR DESCRIPTION
# Retry/Repair
- Endpoints to retry and repair deals.
- Definition of Repair - repairs a deal with specific changes to the metadata request. In this version, we only allow miner and duration to change. This also assumes that the commp was already committed. It'll retry making the storage deal with the same commp but with a different miner /duration.
- Defintion of Retry - this will retry the deal from commp, deal proposal prep, looking for miners and sending the deal.