### PR TITLE
feat: replication factor for e2e deals

### DIFF
--- a/core/replication.go
+++ b/core/replication.go
@@ -26,7 +26,6 @@ type DealReplication struct {
 
 func (r ReplicationService) ReplicateContent(contentSource DealReplication, numberOfReplication int, txn *gorm.DB) []model.Content {
 	var replicatedContents []model.Content
-	//txn.Transaction(func(tx *gorm.DB) error {
 	for i := 0; i < numberOfReplication; i++ {
 		var newContent model.Content
 		var newContentDealProposalParameter model.ContentDealProposalParameters
@@ -73,7 +72,5 @@ func (r ReplicationService) ReplicateContent(contentSource DealReplication, numb
 		replicatedContents = append(replicatedContents, newContent)
 
 	}
-	//return nil
-	//})
 	return replicatedContents
 }

--- a/core/replication.go
+++ b/core/replication.go
@@ -1,76 +1,76 @@
 package core
 
-import (
-	"fmt"
-	model "github.com/application-research/delta-db/db_models"
-	"gorm.io/gorm"
-	"time"
-)
-
-type ReplicationService struct {
-	// `NewReplicationService` is a function that returns a `ReplicationService` struct
-	LightNode *DeltaNode
-}
-
-// NewReplicationService Creating a new `ReplicationService` struct.
-func NewReplicationService(ln *DeltaNode) *ReplicationService {
-	return &ReplicationService{
-		LightNode: ln,
-	}
-}
-
-type DealReplication struct {
-	Content                      model.Content                       `json:"content"`
-	ContentDealProposalParameter model.ContentDealProposalParameters `json:"deal_proposal_parameter"`
-}
-
-func (r ReplicationService) ReplicateContent(contentSource DealReplication, numberOfReplication int, txn *gorm.DB) []model.Content {
-	var replicatedContents []model.Content
-	for i := 0; i < numberOfReplication; i++ {
-		var newContent model.Content
-		var newContentDealProposalParameter model.ContentDealProposalParameters
-		newContent = contentSource.Content
-		newContentDealProposalParameter = contentSource.ContentDealProposalParameter
-		newContent.ID = 0
-
-		err := txn.Create(&newContent).Error
-		if err != nil {
-			//tx.Rollback()
-			fmt.Println(err)
-			return nil
-		}
-
-		newContentDealProposalParameter.ID = 0
-		newContentDealProposalParameter.Content = newContent.ID
-		err = txn.Create(&newContentDealProposalParameter).Error
-		if err != nil {
-			//tx.Rollback()
-			fmt.Println(err)
-			return nil
-		}
-		//	assign a miner
-		minerAssignService := NewMinerAssignmentService()
-		provider, errOnPv := minerAssignService.GetSPWithGivenBytes(newContent.Size)
-		if errOnPv != nil {
-			fmt.Println(errOnPv)
-			return nil
-		}
-
-		contentMinerAssignment := model.ContentMiner{
-			Miner:     provider.Address,
-			Content:   newContent.ID,
-			CreatedAt: time.Now(),
-			UpdatedAt: time.Now(),
-		}
-		err = txn.Create(&contentMinerAssignment).Error
-		if err != nil {
-			//tx.Rollback()
-			fmt.Println(err)
-			return nil
-		}
-
-		replicatedContents = append(replicatedContents, newContent)
-
-	}
-	return replicatedContents
-}
+//
+//import (
+//	"fmt"
+//	model "github.com/application-research/delta-db/db_models"
+//	"gorm.io/gorm"
+//	"time"
+//)
+//
+//type ReplicationService struct {
+//	// `NewReplicationService` is a function that returns a `ReplicationService` struct
+//	LightNode *DeltaNode
+//}
+//
+//// NewReplicationService Creating a new `ReplicationService` struct.
+//func NewReplicationService(ln *DeltaNode) *ReplicationService {
+//	return &ReplicationService{
+//		LightNode: ln,
+//	}
+//}
+//
+//type DealReplication struct {
+//	Content                      model.Content                       `json:"content"`
+//	ContentDealProposalParameter model.ContentDealProposalParameters `json:"deal_proposal_parameter"`
+//}
+//
+//func (r ReplicationService) ReplicateContent(contentSource DealReplication, numberOfReplication int, txn *gorm.DB) []model.Content {
+//	var replicatedContents []model.Content
+//	for i := 0; i < numberOfReplication; i++ {
+//		var newContent model.Content
+//		var newContentDealProposalParameter model.ContentDealProposalParameters
+//		newContent = contentSource.Content
+//		newContentDealProposalParameter = contentSource.ContentDealProposalParameter
+//		newContent.ID = 0
+//
+//		err := txn.Create(&newContent).Error
+//		if err != nil {
+//			fmt.Println(err)
+//			return nil
+//		}
+//
+//		newContentDealProposalParameter.ID = 0
+//		newContentDealProposalParameter.Content = newContent.ID
+//		err = txn.Create(&newContentDealProposalParameter).Error
+//		if err != nil {
+//			//tx.Rollback()
+//			fmt.Println(err)
+//			return nil
+//		}
+//		//	assign a miner
+//		minerAssignService := NewMinerAssignmentService()
+//		provider, errOnPv := minerAssignService.GetSPWithGivenBytes(newContent.Size)
+//		if errOnPv != nil {
+//			fmt.Println(errOnPv)
+//			return nil
+//		}
+//
+//		contentMinerAssignment := model.ContentMiner{
+//			Miner:     provider.Address,
+//			Content:   newContent.ID,
+//			CreatedAt: time.Now(),
+//			UpdatedAt: time.Now(),
+//		}
+//		err = txn.Create(&contentMinerAssignment).Error
+//		if err != nil {
+//			//tx.Rollback()
+//			fmt.Println(err)
+//			return nil
+//		}
+//
+//		replicatedContents = append(replicatedContents, newContent)
+//
+//	}
+//	return replicatedContents
+//}

--- a/core/replication.go
+++ b/core/replication.go
@@ -1,0 +1,79 @@
+package core
+
+import (
+	"fmt"
+	model "github.com/application-research/delta-db/db_models"
+	"gorm.io/gorm"
+	"time"
+)
+
+type ReplicationService struct {
+	// `NewReplicationService` is a function that returns a `ReplicationService` struct
+	LightNode *DeltaNode
+}
+
+// NewReplicationService Creating a new `ReplicationService` struct.
+func NewReplicationService(ln *DeltaNode) *ReplicationService {
+	return &ReplicationService{
+		LightNode: ln,
+	}
+}
+
+type DealReplication struct {
+	Content                      model.Content                       `json:"content"`
+	ContentDealProposalParameter model.ContentDealProposalParameters `json:"deal_proposal_parameter"`
+}
+
+func (r ReplicationService) ReplicateContent(contentSource DealReplication, numberOfReplication int, txn *gorm.DB) []model.Content {
+	var replicatedContents []model.Content
+	//txn.Transaction(func(tx *gorm.DB) error {
+	for i := 0; i < numberOfReplication; i++ {
+		var newContent model.Content
+		var newContentDealProposalParameter model.ContentDealProposalParameters
+		newContent = contentSource.Content
+		newContentDealProposalParameter = contentSource.ContentDealProposalParameter
+		newContent.ID = 0
+
+		err := txn.Create(&newContent).Error
+		if err != nil {
+			//tx.Rollback()
+			fmt.Println(err)
+			return nil
+		}
+
+		newContentDealProposalParameter.ID = 0
+		newContentDealProposalParameter.Content = newContent.ID
+		err = txn.Create(&newContentDealProposalParameter).Error
+		if err != nil {
+			//tx.Rollback()
+			fmt.Println(err)
+			return nil
+		}
+		//	assign a miner
+		minerAssignService := NewMinerAssignmentService()
+		provider, errOnPv := minerAssignService.GetSPWithGivenBytes(newContent.Size)
+		if errOnPv != nil {
+			fmt.Println(errOnPv)
+			return nil
+		}
+
+		contentMinerAssignment := model.ContentMiner{
+			Miner:     provider.Address,
+			Content:   newContent.ID,
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		err = txn.Create(&contentMinerAssignment).Error
+		if err != nil {
+			//tx.Rollback()
+			fmt.Println(err)
+			return nil
+		}
+
+		replicatedContents = append(replicatedContents, newContent)
+
+	}
+	//return nil
+	//})
+	return replicatedContents
+}

--- a/jobs/piece_commp_compute.go
+++ b/jobs/piece_commp_compute.go
@@ -44,18 +44,19 @@ func NewPieceCommpProcessor(ln *core.DeltaNode, content model.Content) IProcesso
 
 // Run The process of generating the commp.
 func (i PieceCommpProcessor) Run() error {
-	i.LightNode.DB.Model(&i.Content).Where("id = ?", i.Content.ID).Updates(model.Content{
-		Status:    utils.CONTENT_PIECE_COMPUTING,
-		UpdatedAt: time.Now(),
-	})
+	var content model.Content
+
+	i.LightNode.DB.Model(&i.Content).Where("id = ?", i.Content.ID).Find(&content)
+	content.Status = utils.CONTENT_PIECE_COMPUTING
+	content.UpdatedAt = time.Now()
+	i.LightNode.DB.Save(&content)
 
 	payloadCid, err := cid.Decode(i.Content.Cid)
 	if err != nil {
-		i.LightNode.DB.Model(&i.Content).Where("id = ?", i.Content.ID).Updates(model.Content{
-			Status:      utils.CONTENT_PIECE_COMPUTING_FAILED,
-			LastMessage: err.Error(),
-			UpdatedAt:   time.Now(),
-		})
+		content.Status = utils.CONTENT_PIECE_COMPUTING_FAILED
+		content.LastMessage = err.Error()
+		content.UpdatedAt = time.Now()
+		i.LightNode.DB.Save(&content)
 	}
 
 	// prepare the commp

--- a/jobs/piece_commp_compute.go
+++ b/jobs/piece_commp_compute.go
@@ -44,9 +44,28 @@ func NewPieceCommpProcessor(ln *core.DeltaNode, content model.Content) IProcesso
 
 // Run The process of generating the commp.
 func (i PieceCommpProcessor) Run() error {
-	var content model.Content
 
+	// if you already have the piece entry for the CID, let's just create a new record with the same commp
+
+	var content model.Content
 	i.LightNode.DB.Model(&i.Content).Where("id = ?", i.Content.ID).Find(&content)
+
+	var existingCommp model.PieceCommitment
+	i.LightNode.DB.Model(&model.PieceCommitment{}).Where("cid = ?", i.Content.Cid).Find(&existingCommp)
+	if existingCommp.ID != 0 {
+
+		// just assign it if it's already there.
+		i.Content.Status = utils.CONTENT_PIECE_ASSIGNED
+		i.Content.PieceCommitmentId = existingCommp.ID
+		i.Content.UpdatedAt = time.Now()
+		i.LightNode.DB.Save(&i.Content)
+
+		// then launch the deal maker with the content and the existing commp
+		item := NewStorageDealMakerProcessor(i.LightNode, i.Content, existingCommp)
+		i.LightNode.Dispatcher.AddJobAndDispatch(item, 1)
+		return nil
+	}
+
 	content.Status = utils.CONTENT_PIECE_COMPUTING
 	content.UpdatedAt = time.Now()
 	i.LightNode.DB.Save(&content)
@@ -136,11 +155,12 @@ func (i PieceCommpProcessor) Run() error {
 	}
 
 	i.LightNode.DB.Create(commpRec)
-	i.LightNode.DB.Model(&i.Content).Where("id = ?", i.Content.ID).Updates(model.Content{
-		Status:            utils.CONTENT_PIECE_ASSIGNED,
-		PieceCommitmentId: commpRec.ID,
-		UpdatedAt:         time.Now(),
-	})
+
+	// update the content record
+	i.Content.Status = utils.CONTENT_PIECE_ASSIGNED
+	i.Content.PieceCommitmentId = commpRec.ID
+	i.Content.UpdatedAt = time.Now()
+	i.LightNode.DB.Save(&i.Content)
 
 	// add this to the job queue
 	item := NewStorageDealMakerProcessor(i.LightNode, i.Content, *commpRec)

--- a/jobs/storage_deal_maker.go
+++ b/jobs/storage_deal_maker.go
@@ -341,6 +341,7 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 			strings.Contains(errProp.Error(), "miner is not accepting unverified storage deals"),
 			strings.Contains(errProp.Error(), "Deal rejected | Under maintenance, retry later"),
 			strings.Contains(errProp.Error(), "Deal rejected | Price below acceptance for such deal"),
+			strings.Contains(errProp.Error(), "Deal rejected | Such deal is not accepted"),
 			strings.Contains(errProp.Error(), "send proposal rpc:"):
 
 			i.LightNode.DB.Model(&deal).Where("id = ?", deal.ID).Updates(&contentDealToUpdate)


### PR DESCRIPTION
# Changes

- Added `replication` on the metadata. User can now set this to a max of 6. 
- if `replication` is given, a new field on the response called `replicated_content` with an array of content_ids will be returned. 
- this is only for online (e2e) deals.
- if auto_retry is set, all deals will be automatically retried when failed until it gets a miner that will accept the deal.
