### PR TITLE
feat: added support for unverified deal max price

### DIFF
--- a/api/deal.go
+++ b/api/deal.go
@@ -393,12 +393,6 @@ func handleExistingContentsAdd(c echo.Context, node *core.DeltaNode) error {
 				}
 				return 0
 			}()
-			dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
-				if dealRequest.UnverifiedDealMaxPrice != 0 {
-					return dealRequest.UnverifiedDealMaxPrice
-				}
-				return 0
-			}()
 
 			dealProposalParam.Label = func() string {
 				if dealRequest.Label != "" {
@@ -599,12 +593,6 @@ func handleExistingContentAdd(c echo.Context, node *core.DeltaNode) error {
 		dealProposalParam.CreatedAt = time.Now()
 		dealProposalParam.UpdatedAt = time.Now()
 		dealProposalParam.Content = content.ID
-		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
-			if dealRequest.UnverifiedDealMaxPrice != 0 {
-				return dealRequest.UnverifiedDealMaxPrice
-			}
-			return 0
-		}()
 		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
 			if dealRequest.UnverifiedDealMaxPrice != 0 {
 				return dealRequest.UnverifiedDealMaxPrice
@@ -821,12 +809,6 @@ func handleEndToEndDeal(c echo.Context, node *core.DeltaNode) error {
 		dealProposalParam.CreatedAt = time.Now()
 		dealProposalParam.UpdatedAt = time.Now()
 		dealProposalParam.Content = content.ID
-		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
-			if dealRequest.UnverifiedDealMaxPrice != 0 {
-				return dealRequest.UnverifiedDealMaxPrice
-			}
-			return 0
-		}()
 		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
 			if dealRequest.UnverifiedDealMaxPrice != 0 {
 				return dealRequest.UnverifiedDealMaxPrice
@@ -1080,12 +1062,6 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 			}
 			return 0
 		}()
-		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
-			if dealRequest.UnverifiedDealMaxPrice != 0 {
-				return dealRequest.UnverifiedDealMaxPrice
-			}
-			return 0
-		}()
 		dealProposalParam.Label = func() string {
 			if dealRequest.Label != "" {
 				return dealRequest.Label
@@ -1299,12 +1275,6 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 			dealProposalParam.CreatedAt = time.Now()
 			dealProposalParam.UpdatedAt = time.Now()
 			dealProposalParam.Content = content.ID
-			dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
-				if dealRequest.UnverifiedDealMaxPrice != 0 {
-					return dealRequest.UnverifiedDealMaxPrice
-				}
-				return 0
-			}()
 			dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
 				if dealRequest.UnverifiedDealMaxPrice != 0 {
 					return dealRequest.UnverifiedDealMaxPrice

--- a/api/deal.go
+++ b/api/deal.go
@@ -27,12 +27,11 @@ type CidRequest struct {
 }
 
 type WalletRequest struct {
-	Id                     uint64 `json:"id,omitempty"`
-	Address                string `json:"address,omitempty"`
-	Uuid                   string `json:"uuid,omitempty"`
-	KeyType                string `json:"key_type,omitempty"`
-	PrivateKey             string `json:"private_key,omitempty"`
-	UnverifiedDealMaxPrice int64  `json:"unverified_deal_max_price,omitempty"`
+	Id         uint64 `json:"id,omitempty"`
+	Address    string `json:"address,omitempty"`
+	Uuid       string `json:"uuid,omitempty"`
+	KeyType    string `json:"key_type,omitempty"`
+	PrivateKey string `json:"private_key,omitempty"`
 }
 
 type PieceCommitmentRequest struct {
@@ -42,22 +41,24 @@ type PieceCommitmentRequest struct {
 }
 
 type DealRequest struct {
-	Cid                string                 `json:"cid,omitempty"`
-	Miner              string                 `json:"miner,omitempty"`
-	Duration           int64                  `json:"duration,omitempty"`
-	DurationInDays     int64                  `json:"duration_in_days,omitempty"`
-	Wallet             WalletRequest          `json:"wallet,omitempty"`
-	PieceCommitment    PieceCommitmentRequest `json:"piece_commitment,omitempty"`
-	ConnectionMode     string                 `json:"connection_mode,omitempty"`
-	Size               int64                  `json:"size,omitempty"`
-	StartEpoch         int64                  `json:"start_epoch,omitempty"`
-	StartEpochInDays   int64                  `json:"start_epoch_in_days,omitempty"`
-	Replication        int                    `json:"replication,omitempty"`
-	RemoveUnsealedCopy bool                   `json:"remove_unsealed_copy"`
-	SkipIPNIAnnounce   bool                   `json:"skip_ipni_announce"`
-	AutoRetry          bool                   `json:"auto_retry"`
-	Label              string                 `json:"label,omitempty"`
-	DealVerifyState    string                 `json:"deal_verify_state,omitempty"`
+	Cid                    string                 `json:"cid,omitempty"`
+	Source                 string                 `json:"source,omitempty"`
+	Miner                  string                 `json:"miner,omitempty"`
+	Duration               int64                  `json:"duration,omitempty"`
+	DurationInDays         int64                  `json:"duration_in_days,omitempty"`
+	Wallet                 WalletRequest          `json:"wallet,omitempty"`
+	PieceCommitment        PieceCommitmentRequest `json:"piece_commitment,omitempty"`
+	ConnectionMode         string                 `json:"connection_mode,omitempty"`
+	Size                   int64                  `json:"size,omitempty"`
+	StartEpoch             int64                  `json:"start_epoch,omitempty"`
+	StartEpochInDays       int64                  `json:"start_epoch_in_days,omitempty"`
+	Replication            int                    `json:"replication,omitempty"`
+	RemoveUnsealedCopy     bool                   `json:"remove_unsealed_copy"`
+	SkipIPNIAnnounce       bool                   `json:"skip_ipni_announce"`
+	AutoRetry              bool                   `json:"auto_retry"`
+	Label                  string                 `json:"label,omitempty"`
+	DealVerifyState        string                 `json:"deal_verify_state,omitempty"`
+	UnverifiedDealMaxPrice int64                  `json:"unverified_deal_max_price,omitempty"`
 }
 
 // DealResponse Creating a new struct called DealResponse and then returning it.
@@ -386,6 +387,18 @@ func handleExistingContentsAdd(c echo.Context, node *core.DeltaNode) error {
 			dealProposalParam.CreatedAt = time.Now()
 			dealProposalParam.UpdatedAt = time.Now()
 			dealProposalParam.Content = content.ID
+			dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+				if dealRequest.UnverifiedDealMaxPrice != 0 {
+					return dealRequest.UnverifiedDealMaxPrice
+				}
+				return 0
+			}()
+			dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+				if dealRequest.UnverifiedDealMaxPrice != 0 {
+					return dealRequest.UnverifiedDealMaxPrice
+				}
+				return 0
+			}()
 
 			dealProposalParam.Label = func() string {
 				if dealRequest.Label != "" {
@@ -451,6 +464,8 @@ func handleExistingContentsAdd(c echo.Context, node *core.DeltaNode) error {
 // @Accept  json
 // @Produce  json
 func handleExistingContentAdd(c echo.Context, node *core.DeltaNode) error {
+
+	// TODO: this needs a source
 	var dealRequest DealRequest
 
 	// lets record this.
@@ -584,6 +599,18 @@ func handleExistingContentAdd(c echo.Context, node *core.DeltaNode) error {
 		dealProposalParam.CreatedAt = time.Now()
 		dealProposalParam.UpdatedAt = time.Now()
 		dealProposalParam.Content = content.ID
+		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+			if dealRequest.UnverifiedDealMaxPrice != 0 {
+				return dealRequest.UnverifiedDealMaxPrice
+			}
+			return 0
+		}()
+		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+			if dealRequest.UnverifiedDealMaxPrice != 0 {
+				return dealRequest.UnverifiedDealMaxPrice
+			}
+			return 0
+		}()
 		dealProposalParam.Label = func() string {
 			if dealRequest.Label != "" {
 				return dealRequest.Label
@@ -794,6 +821,18 @@ func handleEndToEndDeal(c echo.Context, node *core.DeltaNode) error {
 		dealProposalParam.CreatedAt = time.Now()
 		dealProposalParam.UpdatedAt = time.Now()
 		dealProposalParam.Content = content.ID
+		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+			if dealRequest.UnverifiedDealMaxPrice != 0 {
+				return dealRequest.UnverifiedDealMaxPrice
+			}
+			return 0
+		}()
+		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+			if dealRequest.UnverifiedDealMaxPrice != 0 {
+				return dealRequest.UnverifiedDealMaxPrice
+			}
+			return 0
+		}()
 		dealProposalParam.Label = func() string {
 			if dealRequest.Label != "" {
 				return dealRequest.Label
@@ -1035,6 +1074,18 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 		dealProposalParam.CreatedAt = time.Now()
 		dealProposalParam.UpdatedAt = time.Now()
 		dealProposalParam.Content = content.ID
+		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+			if dealRequest.UnverifiedDealMaxPrice != 0 {
+				return dealRequest.UnverifiedDealMaxPrice
+			}
+			return 0
+		}()
+		dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+			if dealRequest.UnverifiedDealMaxPrice != 0 {
+				return dealRequest.UnverifiedDealMaxPrice
+			}
+			return 0
+		}()
 		dealProposalParam.Label = func() string {
 			if dealRequest.Label != "" {
 				return dealRequest.Label
@@ -1248,6 +1299,18 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 			dealProposalParam.CreatedAt = time.Now()
 			dealProposalParam.UpdatedAt = time.Now()
 			dealProposalParam.Content = content.ID
+			dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+				if dealRequest.UnverifiedDealMaxPrice != 0 {
+					return dealRequest.UnverifiedDealMaxPrice
+				}
+				return 0
+			}()
+			dealProposalParam.UnverifiedDealMaxPrice = func() int64 {
+				if dealRequest.UnverifiedDealMaxPrice != 0 {
+					return dealRequest.UnverifiedDealMaxPrice
+				}
+				return 0
+			}()
 			dealProposalParam.Label = func() string {
 				if dealRequest.Label != "" {
 					return dealRequest.Label
@@ -1372,7 +1435,7 @@ func ValidateMeta(dealRequest DealRequest) error {
 	//	return errors.New("miner is required")
 	//}
 
-	if (DealRequest{} != dealRequest && dealRequest.Wallet.UnverifiedDealMaxPrice > 0) {
+	if (DealRequest{} != dealRequest && dealRequest.UnverifiedDealMaxPrice > 0) {
 		if dealRequest.DealVerifyState != utils.DEAL_UNVERIFIED {
 			return errors.New("unverified_deal_max_price is only valid for unverified deals")
 		}

--- a/docs/deal-metadata.md
+++ b/docs/deal-metadata.md
@@ -7,6 +7,10 @@ The metadata request is used to create a deal. It contains the information requi
 The `cid` field is the cid of the content to be stored. This is only required if the `connection_mode` is `import`. If the `connection_mode` is `e2e`, then the `cid` field is not required.
 # miner
 The `miner` field is the miner to store the content. This is required.
+# source
+This is the source mulitaddress on where to retrieve the given cid. This is only required when the "cid" field is given.
+# unverified_deal_max_price
+The `unverified_deal_max_price` field is the maximum price to pay for an unverified deal. This is required only if the `deal_verify_state` is "unverified". If no `unverified_deal_max_price` is specified, Delta will use the default value of 0.000000000000000000 FIL.
 # wallet
 The `wallet` field is the wallet to use to make the deal. This is optional. If no wallet is specified, Delta will use the default wallet that it generated when it was started.
 ## address

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
-	github.com/application-research/delta-db v0.0.2-0.20230401154302-62cefd7da39f
+	github.com/application-research/delta-db v0.0.2-0.20230413035837-02ac624c0e96
 	github.com/application-research/filclient v0.5.0-rc1.0.20230331195738-9826f79f0648
 	github.com/application-research/whypfs-core v0.1.1
 	github.com/caarlos0/env/v6 v6.10.1

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYU
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/application-research/delta-db v0.0.2-0.20230401154302-62cefd7da39f h1:K4Be2ulAxtyM3nx5h2+SLD7Sy7WHWIPsNIize7/grgI=
-github.com/application-research/delta-db v0.0.2-0.20230401154302-62cefd7da39f/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
+github.com/application-research/delta-db v0.0.2-0.20230413035837-02ac624c0e96 h1:Q11YFk3nAu6zH690TxEnYLG/7lH3fW/DygKLJvAfQf4=
+github.com/application-research/delta-db v0.0.2-0.20230413035837-02ac624c0e96/go.mod h1:LkFnhccvtKmSNHCatQNlKNjEAV/30w/e50n+A9hzCaU=
 github.com/application-research/filclient v0.5.0-rc1.0.20230331195738-9826f79f0648 h1:58+odb1yvlrhuWbmpcAu7IKN4/0+LOP8XjKP3JxOPGo=
 github.com/application-research/filclient v0.5.0-rc1.0.20230331195738-9826f79f0648/go.mod h1:HSCZh+v53XTGMwHGyoKpedQH+PlwcmKkMFCYx/Q3hMk=
 github.com/application-research/whypfs-core v0.1.1 h1:BY40N15Ge9BlyAT3f4T4B/CAlaL7A1RYaRrNS3HIyEk=

--- a/jobs/retry.go
+++ b/jobs/retry.go
@@ -34,7 +34,6 @@ func (i RetryProcessor) Run() error {
 
 	// Checking the status of the content and requeue the job if needed.
 	for _, content := range contents {
-
 		// get the piece
 		// This is the retry logic.
 		if content.Status == utils.CONTENT_PINNED || content.Status == utils.CONTENT_PIECE_COMPUTING {
@@ -46,9 +45,7 @@ func (i RetryProcessor) Run() error {
 				CreatedAt: time.Now(),
 				UpdatedAt: time.Now(),
 			})
-
 			i.LightNode.Dispatcher.AddJobAndDispatch(NewPieceCommpProcessor(i.LightNode, content), 1)
-
 		} else if content.Status == utils.CONTENT_PIECE_COMPUTED || content.Status == utils.CONTENT_DEAL_SENDING_PROPOSAL || content.Status == utils.CONTENT_DEAL_MAKING_PROPOSAL {
 			var pieceCommp model.PieceCommitment
 			i.LightNode.DB.Model(&model.PieceCommitment{}).Where("id = (select piece_commitment_id from contents c where c.id = ?)", content.ID).Find(&pieceCommp)


### PR DESCRIPTION
# Changes

- allow the user to specify the max price of an unverified deal.
- requires that the deal_verify_state = "unverified" and that the wallet associated to the deal, either manual or default wallet has FIL on it.