### PR TITLE
fix the unverified deal support on single import request

### DIFF
--- a/api/deal.go
+++ b/api/deal.go
@@ -1069,12 +1069,11 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 			return content.Cid
 		}()
 
-		dealProposalParam.SkipIPNIAnnounce = dealRequest.SkipIPNIAnnounce
 		dealProposalParam.VerifiedDeal = func() bool {
-			if dealRequest.DealVerifyState == utils.DEAL_VERIFIED {
-				return true
+			if dealRequest.DealVerifyState == utils.DEAL_UNVERIFIED {
+				return false
 			}
-			return false
+			return true
 		}()
 
 		if dealRequest.StartEpochInDays != 0 && dealRequest.DurationInDays != 0 {

--- a/api/deal.go
+++ b/api/deal.go
@@ -939,12 +939,6 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 		return err
 	}
 
-	// specify the connection mode
-	var connMode = dealRequest.ConnectionMode
-	if connMode == "" || (connMode != utils.CONNECTION_MODE_E2E && connMode != utils.CONNECTION_MODE_IMPORT) {
-		connMode = "e2e"
-	}
-
 	err = ValidatePieceCommitmentMeta(dealRequest.PieceCommitment)
 	if err != nil {
 		return err
@@ -1152,12 +1146,6 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 			if err != nil {
 				tx.Rollback()
 				return err
-			}
-
-			// specify the connection mode
-			var connMode = dealRequest.ConnectionMode
-			if connMode == "" || (connMode != utils.CONNECTION_MODE_E2E && connMode != utils.CONNECTION_MODE_IMPORT) {
-				connMode = "e2e"
 			}
 
 			err = ValidatePieceCommitmentMeta(dealRequest.PieceCommitment)
@@ -1474,7 +1462,11 @@ func ValidateMeta(dealRequest DealRequest) error {
 		(dealRequest.PieceCommitment.PaddedPieceSize == 0 && dealRequest.PieceCommitment.UnPaddedPieceSize == 0) &&
 		(dealRequest.Size == 0) {
 		return errors.New("piece commitment is invalid, make sure you have the cid, piece_cid, size and padded_piece_size or unpadded_piece_size")
+	}
 
+	// size is required
+	if (PieceCommitmentRequest{} != dealRequest.PieceCommitment && dealRequest.Size == 0) {
+		return errors.New("piece commitment is invalid, make sure you have the cid, piece_cid, size and padded_piece_size or unpadded_piece_size")
 	}
 
 	if (WalletRequest{} != dealRequest.Wallet && dealRequest.Wallet.Address == "") {

--- a/api/deal.go
+++ b/api/deal.go
@@ -979,7 +979,7 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 			PieceCommitmentId: pieceCommp.ID,
 			AutoRetry:         dealRequest.AutoRetry,
 			Status:            utils.CONTENT_DEAL_MAKING_PROPOSAL,
-			ConnectionMode:    connMode,
+			ConnectionMode:    dealRequest.ConnectionMode,
 			CreatedAt:         time.Now(),
 			UpdatedAt:         time.Now(),
 		}
@@ -1188,7 +1188,7 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 				PieceCommitmentId: pieceCommp.ID,
 				AutoRetry:         dealRequest.AutoRetry,
 				Status:            utils.CONTENT_DEAL_MAKING_PROPOSAL,
-				ConnectionMode:    connMode,
+				ConnectionMode:    dealRequest.ConnectionMode,
 				CreatedAt:         time.Now(),
 				UpdatedAt:         time.Now(),
 			}

--- a/jobs/storage_deal_maker.go
+++ b/jobs/storage_deal_maker.go
@@ -152,6 +152,7 @@ func (i *StorageDealMakerProcessor) makeStorageDeal(content *model.Content, piec
 			i.LightNode.DB.Save(&contentToUpdate)
 			return xerrors.New("insufficient funds")
 		}
+
 		priceBigInt = unverifiedDealPrice
 	} else {
 		verifiedPrice, errVerPrice := types.BigFromString("0")


### PR DESCRIPTION
# Changes

quick chore/fix to set the single import request to use "verified" deals setting as default.