### PR TITLE
feat: Inclusion proofs

### DIFF
--- a/api/deal.go
+++ b/api/deal.go
@@ -95,15 +95,11 @@ var statsService *core.StatsService
 func ConfigureDealRouter(e *echo.Group, node *core.DeltaNode) {
 
 	statsService = core.NewStatsStatsService(node)
-	//replicationService = core.NewReplicationService(node)
 	dealMake := e.Group("/deal")
 
 	// upload limiter middleware
 	dealMake.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return checkMetaFlags(next, node)
-	})
-	dealMake.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return checkResourceLimits(next, node)
 	})
 
 	dealPrepare := dealMake.Group("/prepare")

--- a/api/deal.go
+++ b/api/deal.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"database/sql"
+	. "delta/api/models"
 	"delta/core"
 	"delta/jobs"
 	"delta/utils"
@@ -24,69 +25,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type CidRequest struct {
-	Cids []string `json:"cids"`
-}
-
-type WalletRequest struct {
-	Id         uint64 `json:"id,omitempty"`
-	Address    string `json:"address,omitempty"`
-	Uuid       string `json:"uuid,omitempty"`
-	KeyType    string `json:"key_type,omitempty"`
-	PrivateKey string `json:"private_key,omitempty"`
-}
-
-type PieceCommitmentRequest struct {
-	Piece             string `json:"piece_cid,omitempty"`
-	PaddedPieceSize   uint64 `json:"padded_piece_size,omitempty"`
-	UnPaddedPieceSize uint64 `json:"unpadded_piece_size,omitempty"`
-}
-
-type TransferParameters struct {
-	URL     string      `json:"url,omitempty"`
-	Headers interface{} `json:"headers,omitempty"`
-}
-
-type DealRequest struct {
-	Cid                    string                 `json:"cid,omitempty"`
-	Miner                  string                 `json:"miner,omitempty"`
-	Duration               int64                  `json:"duration,omitempty"`
-	DurationInDays         int64                  `json:"duration_in_days,omitempty"`
-	Wallet                 WalletRequest          `json:"wallet,omitempty"`
-	PieceCommitment        PieceCommitmentRequest `json:"piece_commitment,omitempty"`
-	TransferParameters     TransferParameters     `json:"transfer_parameters,omitempty"`
-	ConnectionMode         string                 `json:"connection_mode,omitempty"`
-	Size                   int64                  `json:"size,omitempty"`
-	StartEpoch             int64                  `json:"start_epoch,omitempty"`
-	StartEpochInDays       int64                  `json:"start_epoch_in_days,omitempty"`
-	Replication            int                    `json:"replication,omitempty"`
-	RemoveUnsealedCopy     bool                   `json:"remove_unsealed_copy"`
-	SkipIPNIAnnounce       bool                   `json:"skip_ipni_announce"`
-	AutoRetry              bool                   `json:"auto_retry"`
-	Label                  string                 `json:"label,omitempty"`
-	DealVerifyState        string                 `json:"deal_verify_state,omitempty"`
-	UnverifiedDealMaxPrice string                 `json:"unverified_deal_max_price,omitempty"`
-}
-
-// DealResponse Creating a new struct called DealResponse and then returning it.
-type DealResponse struct {
-	Status                       string         `json:"status"`
-	Message                      string         `json:"message"`
-	ContentId                    int64          `json:"content_id,omitempty"`
-	DealRequest                  interface{}    `json:"deal_request_meta,omitempty"`
-	DealProposalParameterRequest interface{}    `json:"deal_proposal_parameter_request_meta,omitempty"`
-	ReplicatedContents           []DealResponse `json:"replicated_contents,omitempty"`
-}
-
-type DealReplication struct {
-	Content                      model.Content                       `json:"content"`
-	ContentDealProposalParameter model.ContentDealProposalParameters `json:"deal_proposal_parameter"`
-	DealRequest                  DealRequest                         `json:"deal_request"`
-}
-
 var statsService *core.StatsService
-
-//var replicationService *core.ReplicationService
 
 // ConfigureDealRouter It's a function that takes a pointer to an echo.Group and a pointer to a DeltaNode, and then it adds a bunch of routes
 // to the echo.Group

--- a/api/deal.go
+++ b/api/deal.go
@@ -27,10 +27,8 @@ import (
 
 var statsService *core.StatsService
 
-// ConfigureDealRouter It's a function that takes a pointer to an echo.Group and a pointer to a DeltaNode, and then it adds a bunch of routes
-// to the echo.Group
-// `ConfigureDealRouter` is a function that takes a `Group` and a `DeltaNode` and configures the `Group` to handle the
-// `DeltaNode`'s deal-making functionality
+// ConfigureDealRouter It's a function that takes a pointer to an echo.Group and a pointer
+// to a DeltaNode, and then it adds a bunch of routes to the echo.Group
 func ConfigureDealRouter(e *echo.Group, node *core.DeltaNode) {
 
 	statsService = core.NewStatsStatsService(node)
@@ -98,10 +96,9 @@ func ConfigureDealRouter(e *echo.Group, node *core.DeltaNode) {
 	})
 }
 
-// > check if the sum(size) transfer-started and created_at within instance_start time
-//
-// The above function is a middleware that checks if the sum of the size of all the files that have been transferred and
-// created_at within instance_start time
+// checkMetaFlags checks if the request is disabled or if the node is in maintenance mode
+// This function takes in a handler function and a DeltaNode object and returns a function that checks for meta flags in
+// the context before calling the handler.
 func checkMetaFlags(next echo.HandlerFunc, node *core.DeltaNode) func(c echo.Context) error {
 	return func(c echo.Context) error {
 
@@ -128,6 +125,7 @@ func checkMetaFlags(next echo.HandlerFunc, node *core.DeltaNode) func(c echo.Con
 	}
 }
 
+// checkResourceLimits checks if the sum of the size of all the files that are currently being transferred is greater
 // It checks if the sum of the size of all the files that are currently being transferred is greater than the number of
 // CPUs multiplied by the number of bytes per CPU. If it is, then it returns an error
 func checkResourceLimits(next echo.HandlerFunc, node *core.DeltaNode) func(c echo.Context) error {
@@ -375,7 +373,7 @@ func handleExistingContentsAdd(c echo.Context, node *core.DeltaNode) error {
 // handleExistingContentAdd handles the request to add content to the network
 // @Summary Add content to the network
 // @Description Add content to the network
-// @Tags Content
+// @Tags deal
 // @Accept  json
 // @Produce  json
 func handleExistingContentAdd(c echo.Context, node *core.DeltaNode) error {
@@ -582,6 +580,11 @@ func handleExistingContentAdd(c echo.Context, node *core.DeltaNode) error {
 	return nil
 }
 
+// handleEndToEndDeal This function handles the end-to-end deal process for a given
+// @Summary End-to-end deal
+// @Description This endpoint allows you to make a deal request with a single request
+// @Tags deal
+// file and metadata in a Go application.
 func handleEndToEndDeal(c echo.Context, node *core.DeltaNode) error {
 	var dealRequest DealRequest
 
@@ -863,6 +866,10 @@ func handleEndToEndDeal(c echo.Context, node *core.DeltaNode) error {
 	return nil
 }
 
+// handleOnlineImportDeal handles the online import deal request
+// This function handles an online import deal request by validating the request,
+// creating a piece commitment record, assigning a miner, creating a wallet request object,
+// creating a content deal proposal, and dispatching a storage deal making job.
 func handleOnlineImportDeal(c echo.Context, node *core.DeltaNode) error {
 	var dealRequest DealRequest
 
@@ -1092,7 +1099,7 @@ func handleOnlineImportDeal(c echo.Context, node *core.DeltaNode) error {
 // handleImportDeal handles the request to add a commp record.
 // @Summary Add a commp record
 // @Description Add a commp record
-// @Tags deals
+// @Tags deal
 // @Accept  json
 // @Produce  json
 func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
@@ -1334,6 +1341,10 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 	return nil
 }
 
+// handleMultipleOnlineImportDeals handles multiple online import deals.
+// This function handles multiple online import deals by validating the request,
+// creating a piece commitment, assigning a miner and wallet, creating a content deal proposal,
+// and dispatching a storage deal making job.
 func handleMultipleOnlineImportDeals(c echo.Context, node *core.DeltaNode) error {
 	var dealRequests []DealRequest
 
@@ -1566,6 +1577,8 @@ func handleMultipleOnlineImportDeals(c echo.Context, node *core.DeltaNode) error
 	return nil
 }
 
+// handleMultipleBatchImportDeals handles multiple deals in a single request
+// This function handles the import of multiple deals in batches.
 func handleMultipleBatchImportDeals(c echo.Context, node *core.DeltaNode) error {
 	var dealRequests []DealRequest
 
@@ -2086,7 +2099,10 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 	return nil
 }
 
-// It takes a contentId as a parameter, looks up the status of the content, and returns the status as JSON
+// handleContentStats is a function or method in the Go programming language.
+// The above code is not complete and does not provide enough information to determine what it is doing.
+// It appears to be a function or method named "handleContentStats" in the Go programming language, but without the rest of the code or
+// context, it is impossible to determine its purpose or functionality.
 func handleContentStats(c echo.Context, statsService core.StatsService) error {
 	contentIdParam := c.Param("contentId")
 	contentId, err := strconv.Atoi(contentIdParam)
@@ -2106,7 +2122,8 @@ func handleContentStats(c echo.Context, statsService core.StatsService) error {
 	return c.JSON(200, status)
 }
 
-// It takes a piece commitment ID, looks up the status of the piece commitment, and returns the status
+// handleCommitmentPieceStats is a function or method in the Go programming language.
+// This function handles commitment piece statistics in a Go web application using a StatsService.
 func handleCommitmentPieceStats(c echo.Context, statsService core.StatsService) error {
 	pieceCommitmentIdParam := c.Param("piece-commitmentId")
 	pieceCommitmentId, err := strconv.Atoi(pieceCommitmentIdParam)
@@ -2131,15 +2148,16 @@ type ValidateMetaResult struct {
 }
 
 // ValidatePieceCommitmentMeta `ValidateMeta` validates the `DealRequest` struct and returns an error if the request is invalid
+// This function validates a piece commitment request against a DeltaNode in Go.
 func ValidatePieceCommitmentMeta(pieceCommitmentRequest PieceCommitmentRequest, node *core.DeltaNode) error {
 	if (PieceCommitmentRequest{} == pieceCommitmentRequest) {
 		return errors.New("invalid piece_commitment request. piece_commitment is required")
 	}
-
 	return nil
 }
 
-// It validates the deal request and returns an error if the request is invalid
+// ValidateMeta `ValidateMeta` validates the `DealRequest` struct and returns an error if the request is invalid
+// The function validates metadata for a deal request in Go programming language.
 func ValidateMeta(dealRequest DealRequest, node *core.DeltaNode) error {
 
 	if (DealRequest{} == dealRequest) {
@@ -2260,6 +2278,8 @@ type ReplicatedContent struct {
 	DealResponse DealResponse
 }
 
+// ReplicateContent replicates content from a source to a node and returns a list of replicated content.
+// This function replicates content from a source to a node and returns a list of replicated content.
 func ReplicateContent(node *core.DeltaNode, contentSource DealReplication, dealRequest DealRequest, txn *gorm.DB) []ReplicatedContent {
 	var replicatedContents []ReplicatedContent
 	for i := 0; i < dealRequest.Replication; i++ {
@@ -2322,30 +2342,35 @@ func ReplicateContent(node *core.DeltaNode, contentSource DealReplication, dealR
 	return replicatedContents
 }
 
-// It takes a request, and returns a response
+// handlePrepareContent It takes a request, and returns a response
+// This function handles preparing content for a given DeltaNode and updates statistics using a StatsService.
 func handlePrepareContent(c echo.Context, node *core.DeltaNode, statsService core.StatsService) {
 	// > This function is called when a node receives a `PrepareCommitmentPiece` message
 }
+
+// handlePrepareCommitmentPiece It takes a request, and returns a response
+// This function handles preparing commitment pieces for a given DeltaNode and updates statistics using a StatsService.
 func handlePrepareCommitmentPiece() {
 	// > This function is called when the user clicks the "Prepare Commitment Pieces" button. It takes the user's input and
 	// prepares the commitment pieces
 }
+
+// handlePrepareCommitmentPieces It takes a request, and returns a response
+// This function handles preparing commitment pieces for a given DeltaNode and updates statistics using a StatsService.
 func handlePrepareCommitmentPieces() {
 	// This function handles the announcement of content.
 }
 
-// This function is called when the user clicks the "Announce Content" button. It takes the user's input and...
+// handleAnnounceContent It takes a request, and returns a response
+// This function handles the announcement of content.
 func handleAnnounceContent() {
 	//	> This function is called when the user clicks the "Announce Content" button. It takes the user's input and
 }
 
-// > The function `handleAnnounceCommitmentPiece` is called when a `AnnounceCommitmentPiece` message is received
-func handleAnnounceCommitmentPiece() {
+// handleAnnounceCommitmentPiece It takes a request, and returns a response
+// This function handles the announcement of commitment pieces.
+func handleAnnounceCommitmentPiece() {}
 
-}
-
-// > This function is called when a commitment piece is received from a peer
-
-func handleAnnounceCommitmentPieces() {
-
-}
+// handleAnnounceCommitmentPieces It takes a request, and returns a response
+// This function handles the announcement of commitment pieces.
+func handleAnnounceCommitmentPieces() {}

--- a/api/models/deal.go
+++ b/api/models/deal.go
@@ -1,0 +1,63 @@
+package models
+
+import model "github.com/application-research/delta-db/db_models"
+
+type CidRequest struct {
+	Cids []string `json:"cids"`
+}
+
+type WalletRequest struct {
+	Id         uint64 `json:"id,omitempty"`
+	Address    string `json:"address,omitempty"`
+	Uuid       string `json:"uuid,omitempty"`
+	KeyType    string `json:"key_type,omitempty"`
+	PrivateKey string `json:"private_key,omitempty"`
+}
+
+type PieceCommitmentRequest struct {
+	Piece             string `json:"piece_cid,omitempty"`
+	PaddedPieceSize   uint64 `json:"padded_piece_size,omitempty"`
+	UnPaddedPieceSize uint64 `json:"unpadded_piece_size,omitempty"`
+}
+
+type TransferParameters struct {
+	URL     string      `json:"url,omitempty"`
+	Headers interface{} `json:"headers,omitempty"`
+}
+
+type DealRequest struct {
+	Cid                    string                 `json:"cid,omitempty"`
+	Miner                  string                 `json:"miner,omitempty"`
+	Duration               int64                  `json:"duration,omitempty"`
+	DurationInDays         int64                  `json:"duration_in_days,omitempty"`
+	Wallet                 WalletRequest          `json:"wallet,omitempty"`
+	PieceCommitment        PieceCommitmentRequest `json:"piece_commitment,omitempty"`
+	TransferParameters     TransferParameters     `json:"transfer_parameters,omitempty"`
+	ConnectionMode         string                 `json:"connection_mode,omitempty"`
+	Size                   int64                  `json:"size,omitempty"`
+	StartEpoch             int64                  `json:"start_epoch,omitempty"`
+	StartEpochInDays       int64                  `json:"start_epoch_in_days,omitempty"`
+	Replication            int                    `json:"replication,omitempty"`
+	RemoveUnsealedCopy     bool                   `json:"remove_unsealed_copy"`
+	SkipIPNIAnnounce       bool                   `json:"skip_ipni_announce"`
+	AutoRetry              bool                   `json:"auto_retry"`
+	Label                  string                 `json:"label,omitempty"`
+	DealVerifyState        string                 `json:"deal_verify_state,omitempty"`
+	UnverifiedDealMaxPrice string                 `json:"unverified_deal_max_price,omitempty"`
+}
+
+// DealResponse Creating a new struct called DealResponse and then returning it.
+type DealResponse struct {
+	Status                       string         `json:"status"`
+	Message                      string         `json:"message"`
+	ContentId                    int64          `json:"content_id,omitempty"`
+	DealRequest                  interface{}    `json:"deal_request_meta,omitempty"`
+	DealProposalParameterRequest interface{}    `json:"deal_proposal_parameter_request_meta,omitempty"`
+	ReplicatedContents           []DealResponse `json:"replicated_contents,omitempty"`
+}
+
+type DealReplication struct {
+	Content                      model.Content                       `json:"content"`
+	ContentDealProposalParameter model.ContentDealProposalParameters `json:"deal_proposal_parameter"`
+	DealRequest                  DealRequest                         `json:"deal_request"`
+}

--- a/api/models/repair_retry.go
+++ b/api/models/repair_retry.go
@@ -1,0 +1,24 @@
+package models
+
+import model "github.com/application-research/delta-db/db_models"
+
+type RetryDealResponse struct {
+	Status       string      `json:"status"`
+	Message      string      `json:"message"`
+	NewContentId int64       `json:"new_content_id,omitempty"`
+	OldContentId interface{} `json:"old_content_id,omitempty"`
+}
+
+type MultipleImportRequest struct {
+	ContentID   string      `json:"content_id"`
+	DealRequest DealRequest `json:"metadata"`
+}
+
+type ImportRetryRequest struct {
+	ContentIds []string `json:"content_ids"`
+}
+type ImportRetryResponse struct {
+	Message     string        `json:"message"`
+	Content     model.Content `json:"content"`
+	DealRequest DealRequest   `json:"metadata"`
+}

--- a/api/models/stats.go
+++ b/api/models/stats.go
@@ -1,0 +1,11 @@
+package models
+
+type StatsCheckResponse struct {
+	Content struct {
+		ID      int64  `json:"id"`
+		Name    string `json:"name"`
+		Cid     string `json:"cid,omitempty"`
+		Status  string `json:"status"`
+		Message string `json:"message,omitempty"`
+	} `json:"content"`
+}

--- a/api/repair_retry.go
+++ b/api/repair_retry.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	. "delta/api/models"
 	"delta/core"
 	"delta/jobs"
 	"delta/utils"
@@ -10,27 +11,6 @@ import (
 	"strings"
 	"time"
 )
-
-type RetryDealResponse struct {
-	Status       string      `json:"status"`
-	Message      string      `json:"message"`
-	NewContentId int64       `json:"new_content_id,omitempty"`
-	OldContentId interface{} `json:"old_content_id,omitempty"`
-}
-
-type MultipleImportRequest struct {
-	ContentID   string      `json:"content_id"`
-	DealRequest DealRequest `json:"metadata"`
-}
-
-type ImportRetryRequest struct {
-	ContentIds []string `json:"content_ids"`
-}
-type ImportRetryResponse struct {
-	Message     string        `json:"message"`
-	Content     model.Content `json:"content"`
-	DealRequest DealRequest   `json:"metadata"`
-}
 
 // ConfigureRepairRouter repair deals (re-create or re-try)
 // It's a function that configures the repair router

--- a/api/stats.go
+++ b/api/stats.go
@@ -8,16 +8,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-type StatsCheckResponse struct {
-	Content struct {
-		ID      int64  `json:"id"`
-		Name    string `json:"name"`
-		Cid     string `json:"cid,omitempty"`
-		Status  string `json:"status"`
-		Message string `json:"message,omitempty"`
-	} `json:"content"`
-}
-
 // ConfigureStatsCheckRouter Creating a new router and adding a route to it.
 // It configures the router for the stats check API
 func ConfigureStatsCheckRouter(e *echo.Group, node *core.DeltaNode) {

--- a/cmd/commp.go
+++ b/cmd/commp.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"delta/api"
+	"delta/api/models"
 	c "delta/config"
 	"delta/core"
 	"delta/utils"
@@ -23,10 +23,10 @@ import (
 )
 
 type PieceCommitmentResult struct {
-	FileName        string                     `json:"file_name,omitempty"`
-	Size            int64                      `json:"size,omitempty"`
-	Cid             string                     `json:"cid,omitempty"`
-	PieceCommitment api.PieceCommitmentRequest `json:"piece_commitment,omitempty"`
+	FileName        string                        `json:"file_name,omitempty"`
+	Size            int64                         `json:"size,omitempty"`
+	Cid             string                        `json:"cid,omitempty"`
+	PieceCommitment models.PieceCommitmentRequest `json:"piece_commitment,omitempty"`
 }
 
 type FilclientCommp struct {

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -93,6 +93,7 @@ func DaemonCmd(cfg *c.DeltaConfig) []*cli.Command {
 			statsCollection := c.Bool("stats-collection")
 			commpMode := c.String("commp-mode")
 			keepCopies := c.Bool("keep-copies")
+			enableInclusionProofs := c.Bool("enable-inclusion-proofs")
 
 			if repo == "" {
 				repo = ".whypfs"
@@ -106,6 +107,10 @@ func DaemonCmd(cfg *c.DeltaConfig) []*cli.Command {
 				cfg.Common.Mode = "cluster"
 			} else {
 				cfg.Common.Mode = mode
+			}
+
+			if enableInclusionProofs {
+				cfg.Common.EnableInclusionProofs = true
 			}
 
 			cfg.Common.EnableWebsocket = enableWebsocket

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -67,6 +67,11 @@ func DaemonCmd(cfg *c.DeltaConfig) []*cli.Command {
 				Usage: "enable miner throttle or not",
 				Value: false,
 			},
+			&cli.BoolFlag{
+				Name:  "enable-inclusion-proofs",
+				Usage: "enable inclusion proofs or not",
+				Value: false,
+			},
 		},
 
 		Action: func(c *cli.Context) error {

--- a/cmd/deal.go
+++ b/cmd/deal.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"bytes"
-	"delta/api"
+	"delta/api/models"
 	c "delta/config"
 	"delta/utils"
 	"encoding/json"
@@ -15,8 +15,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type DealMetadata api.DealRequest
-type DealResponse api.DealResponse
+type DealMetadata models.DealRequest
+type DealResponse models.DealResponse
 
 func DealCmd(cfg *c.DeltaConfig) []*cli.Command {
 	// add a command to run API node

--- a/config/config.go
+++ b/config/config.go
@@ -27,15 +27,16 @@ type DeltaConfig struct {
 	}
 
 	Common struct {
-		Mode                 string `env:"MODE" envDefault:"standalone"`
-		DBDSN                string `env:"DB_DSN" envDefault:"delta.db"`
-		EnableWebsocket      bool   `env:"ENABLE_WEBSOCKET" envDefault:"false"`
-		CommpMode            string `env:"COMMP_MODE" envDefault:"fast"` // option "filboost"
-		StatsCollection      bool   `env:"STATS_COLLECTION" envDefault:"true"`
-		Commit               string `env:"COMMIT"`
-		Version              string `env:"VERSION"`
-		MaxReplicationFactor int    `env:"MAX_REPLICATION_FACTOR" envDefault:"6"`
-		MaxAutoRetry         int    `env:"MAX_AUTO_RETRY" envDefault:"3"`
+		Mode                  string `env:"MODE" envDefault:"standalone"`
+		DBDSN                 string `env:"DB_DSN" envDefault:"delta.db"`
+		EnableWebsocket       bool   `env:"ENABLE_WEBSOCKET" envDefault:"false"`
+		CommpMode             string `env:"COMMP_MODE" envDefault:"fast"` // option "filboost"
+		StatsCollection       bool   `env:"STATS_COLLECTION" envDefault:"true"`
+		Commit                string `env:"COMMIT"`
+		Version               string `env:"VERSION"`
+		MaxReplicationFactor  int    `env:"MAX_REPLICATION_FACTOR" envDefault:"6"`
+		MaxAutoRetry          int    `env:"MAX_AUTO_RETRY" envDefault:"3"`
+		EnableInclusionProofs bool   `env:"ENABLE_INCLUSION_PROOFS" envDefault:"false"`
 	}
 
 	// configurable via env vars

--- a/core/inclusion_proofs.go
+++ b/core/inclusion_proofs.go
@@ -1,0 +1,59 @@
+package core
+
+import (
+	"github.com/filecoin-project/go-data-segment/datasegment"
+	"github.com/filecoin-project/go-data-segment/merkletree"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/ipfs/go-cid"
+)
+
+type InclusionProofService struct {
+	DeltaNode *DeltaNode
+}
+
+func NewInclusionProofService(deltaNode DeltaNode) *InclusionProofService {
+	return &InclusionProofService{
+		DeltaNode: &deltaNode,
+	}
+}
+
+func (i *InclusionProofService) GenerateInclusionProof(pieceInfo abi.PieceInfo, paddedPieceSize abi.PaddedPieceSize) (*datasegment.InclusionProof, error) {
+	aggregate, err := datasegment.NewAggregate(paddedPieceSize, []abi.PieceInfo{pieceInfo})
+	if err != nil {
+		panic(err)
+	}
+	inclusionProof, err := aggregate.ProofForPieceInfo(pieceInfo)
+	if err != nil {
+		return nil, err
+	}
+	// store on the database
+	return inclusionProof, nil
+}
+
+func (i *InclusionProofService) ValidateInclusionProof(cidFromDb string, pieceInfoInput abi.PieceInfo) {
+
+	// load from database
+	//
+	inclusionProof := datasegment.InclusionProof{
+		ProofSubtree: merkletree.ProofData{},
+		ProofIndex:   merkletree.ProofData{},
+	}
+
+	// from database, generate the expected aux data
+	pieceCid, _ := cid.Decode("piececid....")
+	pieceInfoFromDB := abi.PieceInfo{
+		PieceCID: pieceCid,
+		Size:     0,
+	}
+	inclusionVerifiedData := datasegment.VerifierDataForPieceInfo(pieceInfoFromDB)
+	aux, _ := inclusionProof.ComputeExpectedAuxData(inclusionVerifiedData)
+
+	// create a custom aux data to validate against
+	validateAgainst := datasegment.InclusionAuxData{CommPa: pieceInfoInput.PieceCID, SizePa: pieceInfoInput.Size}
+
+	if *aux == validateAgainst {
+		// verified nice!
+	} else {
+		// not verified!
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/filecoin-project/go-amt-ipld/v4 v4.0.0 // indirect
 	github.com/filecoin-project/go-bitfield v0.2.4 // indirect
 	github.com/filecoin-project/go-crypto v0.0.1 // indirect
+	github.com/filecoin-project/go-data-segment v0.0.0-20230426133954-21861aa41012 // indirect
 	github.com/filecoin-project/go-ds-versioning v0.1.2 // indirect
 	github.com/filecoin-project/go-hamt-ipld v0.1.5 // indirect
 	github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 // indirect
@@ -290,7 +291,7 @@ require (
 	go.uber.org/zap v1.24.0 // indirect
 	go4.org v0.0.0-20200411211856-f5505b9728dd // indirect
 	golang.org/x/crypto v0.6.0 // indirect
-	golang.org/x/exp v0.0.0-20230124142953-7f5a42a36c7e // indirect
+	golang.org/x/exp v0.0.0-20230418202329-0354be287a23 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/filecoin-project/go-commp-utils/nonffi v0.0.0-20220905160352-62059082
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-crypto v0.0.1 h1:AcvpSGGCgjaY8y1az6AMfKQWreF/pWO2JJGLl6gCq6o=
 github.com/filecoin-project/go-crypto v0.0.1/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
+github.com/filecoin-project/go-data-segment v0.0.0-20230426133954-21861aa41012 h1:j8J+WWO9QdlFo3MA09WCBHKPHEhx9ouY2ybCxnO5lhU=
+github.com/filecoin-project/go-data-segment v0.0.0-20230426133954-21861aa41012/go.mod h1:c+ALiziYNWQCOKeoMBczxM9kOCcgUtZU1CBXzHVlUGs=
 github.com/filecoin-project/go-data-transfer v1.15.3 h1:zA0XrH9EQ9TtKRFt3joseShvuSNSDYOF01uuZtYghOo=
 github.com/filecoin-project/go-data-transfer v1.15.3/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
@@ -1866,6 +1868,8 @@ golang.org/x/exp v0.0.0-20210615023648-acb5c1269671/go.mod h1:DVyR6MI7P4kEQgvZJS
 golang.org/x/exp v0.0.0-20210714144626-1041f73d31d8/go.mod h1:DVyR6MI7P4kEQgvZJSj1fQGrWIi2RzIrfYWycwheUAc=
 golang.org/x/exp v0.0.0-20230124142953-7f5a42a36c7e h1:EyhfKIkP7IrVSW8c32mNvyenZwaEAIZRRmxfSkLC5xI=
 golang.org/x/exp v0.0.0-20230124142953-7f5a42a36c7e/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230418202329-0354be287a23 h1:4NKENAGIctmZYLK9W+X1kDK8ObBFqOSCJM6WE7CvkJY=
+golang.org/x/exp v0.0.0-20230418202329-0354be287a23/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/jobs/batch_deal.go
+++ b/jobs/batch_deal.go
@@ -1,0 +1,86 @@
+package jobs
+
+import (
+	"context"
+	"delta/api/models"
+	"delta/core"
+	"delta/utils"
+	"fmt"
+	"github.com/application-research/delta-db/db_models"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"time"
+)
+
+type BatchDealRequestProcessor struct {
+	Context     context.Context
+	DealRequest []models.DealRequest
+	LightNode   *core.DeltaNode
+}
+
+func (b BatchDealRequestProcessor) Run() error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func NewBatchDealRequestProcessor(ln *core.DeltaNode, dealRequest []models.DealRequest) IProcessor {
+	return &BatchDealRequestProcessor{
+		Context:     context.Background(),
+		LightNode:   ln,
+		DealRequest: dealRequest,
+	}
+}
+
+type BatchJob struct {
+	DealRequests []models.DealRequest
+	Node         *core.DeltaNode
+}
+
+type BatchJobResult struct {
+	DealResponses []models.DealResponse
+	BatchImportID int64
+	Error         error
+}
+
+func processBatchJob(job BatchJob) BatchJobResult {
+	node := job.Node
+	dealRequests := job.DealRequests
+
+	var dealResponses []models.DealResponse
+	for _, dealRequest := range dealRequests {
+		// Process each deal request
+		// ...
+		fmt.Println(dealRequest)
+		// Append the deal response to the list
+		dealResponses = append(dealResponses, models.DealResponse{
+			// Populate the DealResponse fields accordingly
+		})
+	}
+
+	// Create a batch import object
+	batchImportUuid := uuid.New().String()
+	batchImport := db_models.BatchImport{
+		Uuid:      batchImportUuid,
+		Status:    utils.BATCH_IMPORT_STATUS_STARTED,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	err := node.DB.Create(&batchImport).Error
+	if err != nil {
+		return BatchJobResult{
+			Error: errors.New("Error creating a batch import object"),
+		}
+	}
+
+	// Update the batch import status
+	var batchImportToBeUpdate db_models.BatchImport
+	node.DB.Raw("SELECT * FROM batch_imports WHERE id = ?", batchImport.ID).Scan(&batchImportToBeUpdate)
+	batchImportToBeUpdate.Status = utils.BATCH_IMPORT_STATUS_COMPLETED
+	batchImportToBeUpdate.UpdatedAt = time.Now()
+	node.DB.Save(&batchImportToBeUpdate)
+
+	return BatchJobResult{
+		DealResponses: dealResponses,
+		BatchImportID: batchImport.ID,
+	}
+}


### PR DESCRIPTION
# Changes
- generates inclusion proofs per piece info
- only generates the proofs when `enable-inclusion-proof` is set to true on daemon start.
- saves the proofs on the database
- validates the proof generated against a given piece info