### PR TITLE
feat: pull cid from blockstore for import deals

### DIFF
--- a/api/deal.go
+++ b/api/deal.go
@@ -1450,6 +1450,8 @@ func handleImportDeal(c echo.Context, node *core.DeltaNode) error {
 		var dispatchJobs core.IProcessor
 		if pieceCommp.ID != 0 {
 			dispatchJobs = jobs.NewStorageDealMakerProcessor(node, content, pieceCommp) // straight to storage deal making
+		} else {
+			dispatchJobs = jobs.NewPieceCommpProcessor(node, content) // straight to pieceCommp
 		}
 
 		node.Dispatcher.AddJobAndDispatch(dispatchJobs, 1)
@@ -2199,6 +2201,8 @@ func handleMultipleImportDeals(c echo.Context, node *core.DeltaNode) error {
 			var dispatchJobs core.IProcessor
 			if pieceCommp.ID != 0 {
 				dispatchJobs = jobs.NewStorageDealMakerProcessor(node, content, pieceCommp) // straight to storage deal making
+			} else {
+				dispatchJobs = jobs.NewPieceCommpProcessor(node, content) // straight to pieceCommp
 			}
 
 			node.Dispatcher.AddJob(dispatchJobs)


### PR DESCRIPTION
When an import deal request is made, it is expected that a commp is passed thru the request. However there are a few cases where the request (import deals) have the CID but the commp is not available yet. 

In this change, when the user doesn't specify a commp, it'll generate the commp for the content of the CID. 

**Assumptions:**
- the CID will be fetched from the blockstore (DHT). 
- the CID does not have an existing COMMP record.